### PR TITLE
fix: update Sentry configuration for Next.js 15 compatibility

### DIFF
--- a/.changeset/slick-ears-feel.md
+++ b/.changeset/slick-ears-feel.md
@@ -1,0 +1,5 @@
+---
+'www': patch
+---
+
+Updated Sentry configuration to use instrumentation hooks.

--- a/apps/www/instrumentation-client.ts
+++ b/apps/www/instrumentation-client.ts
@@ -29,3 +29,5 @@ Sentry.init({
 		}),
 	],
 })
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/apps/www/instrumentation.ts
+++ b/apps/www/instrumentation.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/nextjs'
 
 export function register() {
   Sentry.init({
-    dsn: 'https://4a2c4b3b30f0447bb689b752d8af03fd@o312315.ingest.us.sentry.io/5675622',
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   
     // Adjust this value in production, or use tracesSampler for greater control
     tracesSampleRate: 1,
@@ -13,4 +13,21 @@ export function register() {
     // uncomment the line below to enable Spotlight (https://spotlightjs.com)
     // spotlight: process.env.NODE_ENV === 'development',
   })
+}
+
+export async function onRequestError(
+  err: unknown,
+  request: {
+    url: string
+    method: string
+    headers: Record<string, string>
+    path: string
+  },
+  context: {
+    routerKind: string
+    routePath: string
+    routeType: string
+  }
+) {
+  await Sentry.captureRequestError(err, request, context)
 }

--- a/apps/www/sentry.edge.config.ts
+++ b/apps/www/sentry.edge.config.ts
@@ -6,7 +6,7 @@
 import * as Sentry from '@sentry/nextjs'
 
 Sentry.init({
-	dsn: 'https://4a2c4b3b30f0447bb689b752d8af03fd@o312315.ingest.us.sentry.io/5675622',
+	dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
 	// Adjust this value in production, or use tracesSampler for greater control
 	tracesSampleRate: 1,


### PR DESCRIPTION
- Add onRequestError hook in instrumentation.ts to capture errors from nested React server components
- Migrate sentry.client.config.ts to instrumentation-client.ts following Next.js 15 recommendations
- Add onRouterTransitionStart hook for navigation instrumentation
- Replace hard-coded DSNs with NEXT_PUBLIC_SENTRY_DSN environment variable
- Resolve build warnings about outdated Sentry SDK configuration