### PR TITLE
fix(ci): resolve hanging Cypress tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci-www-e2e.yml
+++ b/.github/workflows/ci-www-e2e.yml
@@ -77,7 +77,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       
       - name: Install Cypress binary
-        run: pnpm --filter www cypress install
+        run: pnpm --filter www cypress:install
       
       - name: Build packages
         run: |
@@ -116,6 +116,7 @@ jobs:
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 180
           browser: chrome
+          headless: true
           record: false
           config-file: apps/www/cypress.config.ts
           spec: apps/www/cypress/e2e/routes/public-routes.cy.ts
@@ -161,7 +162,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       
       - name: Install Cypress binary
-        run: pnpm --filter www cypress install
+        run: pnpm --filter www cypress:install
       
       - name: Build packages
         run: |
@@ -210,6 +211,7 @@ jobs:
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 180
           browser: chrome
+          headless: true
           record: false
           config-file: apps/www/cypress.config.ts
           spec: ${{ steps.test-suite.outputs.suite == 'all' && 'apps/www/cypress/e2e/**/*.cy.ts' || format('apps/www/cypress/e2e/{0}/**/*.cy.ts', steps.test-suite.outputs.suite) }}

--- a/apps/www/cypress.config.ts
+++ b/apps/www/cypress.config.ts
@@ -78,6 +78,12 @@ export default defineConfig({
 					launchOptions.args.push('--disable-gpu')
 					launchOptions.args.push('--disable-web-security')
 					launchOptions.args.push('--disable-features=VizDisplayCompositor')
+					launchOptions.args.push('--disable-background-timer-throttling')
+					launchOptions.args.push('--disable-backgrounding-occluded-windows')
+					launchOptions.args.push('--disable-renderer-backgrounding')
+					launchOptions.args.push('--force-color-profile=generic-rgb')
+					launchOptions.args.push('--disable-ipc-flooding-protection')
+					launchOptions.args.push('--window-size=1280,720')
 				}
 				return launchOptions
 			})

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -22,6 +22,7 @@
 		"start": "next start",
 		"lint": "next lint",
 		"cypress": "cypress open",
+		"cypress:install": "cypress install",
 		"cypress:run": "cypress run",
 		"cypress:run:chrome": "cypress run --browser chrome",
 		"cypress:run:firefox": "cypress run --browser firefox",


### PR DESCRIPTION
- Fix installation command: use cypress:install instead of cypress script
- Add explicit headless configuration to prevent GUI mode in CI
- Enhance Chrome browser flags for improved CI stability
- Create dedicated cypress:install script for binary-only installation

Resolves issue where Cypress tests hung indefinitely due to GUI mode attempting to launch in headless CI environment.

🤖 Generated with [Claude Code](https://claude.ai/code)