### PR TITLE
docs: add comprehensive AI agent documentation structure

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,276 @@
+# AGENTS.md - Downbeat Academy Monorepo
+
+This file provides operational guidance for AI coding agents working with the Downbeat Academy monorepo. For architectural overview, see [CLAUDE.md](./CLAUDE.md).
+
+## Monorepo Structure
+
+```
+downbeat-academy/
+├── apps/
+│   ├── www/                    # Next.js main website
+│   └── cms-sanity/            # Sanity CMS
+├── packages/
+│   ├── cadence-core/          # React component library
+│   ├── cadence-icons/         # Icon library
+│   ├── cadence-tokens/        # Design tokens
+│   ├── email/                 # Email templates
+│   ├── typeface-favorit/      # Font package
+│   └── typeface-tiempos-text/ # Font package
+└── docs/                      # Monorepo documentation
+```
+
+## Workspace Commands
+
+### Development
+```bash
+# Start all apps in development
+pnpm dev
+
+# Start specific apps
+pnpm www:dev          # Main website
+pnpm cms:dev          # Sanity CMS
+pnpm icons:dev        # Icons development server
+pnpm core:storybook   # Component library Storybook
+
+# Fresh development (rebuild packages first)
+pnpm dev:fresh
+```
+
+### Building
+```bash
+# Build all apps and packages
+pnpm build
+
+# Build packages only
+pnpm build:packages
+
+# Build specific targets
+pnpm www:build        # Main website
+pnpm cms:build        # Sanity CMS
+pnpm tokens:build     # Design tokens
+pnpm icons:build      # Icon library
+pnpm core:build       # Component library
+```
+
+### Testing
+```bash
+# Run all tests
+pnpm test
+
+# Run E2E tests for www app
+pnpm www:cypress
+```
+
+## Package Dependencies
+
+### Dependency Flow
+```
+www → cadence-core → cadence-tokens
+    → cadence-icons
+    → typeface-favorit
+    → typeface-tiempos-text
+    → email
+
+cms-sanity (independent)
+```
+
+### Critical Rules
+1. **Always build packages before apps**: Changes in `packages/` require rebuilding before apps can use them
+2. **Turbo handles dependencies**: Use turbo commands to ensure proper build order
+3. **Test downstream effects**: Changes in packages affect multiple apps
+
+## Where to Make Changes
+
+### Adding New Components
+- **Location**: `packages/cadence-core/src/components/`
+- **Process**: Build package → Test in Storybook → Use in apps
+- **Commands**: `pnpm core:build && pnpm core:storybook`
+
+### Adding New Icons
+- **Location**: `packages/cadence-icons/src/assets/`
+- **Process**: Add SVG → Run build → Icons available in apps
+- **Commands**: `pnpm icons:build`
+
+### Design Token Changes
+- **Location**: `packages/cadence-tokens/tokens/`
+- **Process**: Update JSON → Build tokens → Rebuild dependent packages
+- **Commands**: `pnpm tokens:build && pnpm build:packages`
+
+### App-Specific Features
+- **WWW App**: `apps/www/src/`
+- **CMS Configuration**: `apps/cms-sanity/schemas/`
+
+### Email Templates
+- **Location**: `packages/email/emails/`
+- **Components**: `packages/email/components/`
+
+## Development Workflows
+
+### 1. Component Development
+```bash
+# 1. Create component in cadence-core
+cd packages/cadence-core
+# Add component files
+
+# 2. Build and test
+pnpm core:build
+pnpm core:storybook
+
+# 3. Use in www app
+cd ../../apps/www
+# Import and use component
+```
+
+### 2. Design System Updates
+```bash
+# 1. Update tokens
+cd packages/cadence-tokens
+# Modify JSON files
+
+# 2. Build tokens and packages
+pnpm tokens:build
+pnpm build:packages
+
+# 3. Test in apps
+pnpm dev
+```
+
+### 3. Full Stack Feature
+```bash
+# 1. Update CMS schema if needed
+cd apps/cms-sanity
+# Modify schemas
+
+# 2. Add components if needed
+cd ../../packages/cadence-core
+# Add new components
+
+# 3. Build packages
+pnpm build:packages
+
+# 4. Implement in www app
+cd ../../apps/www
+# Use components and integrate
+```
+
+## Testing Strategy
+
+### Package Testing
+- **Component Library**: Vitest tests in `cadence-core`
+- **Icons**: Build verification
+- **Tokens**: Style dictionary compilation
+
+### App Testing  
+- **WWW**: Cypress E2E tests (see `apps/www/docs/`)
+- **CMS**: Manual testing in Sanity Studio
+
+### Integration Testing
+```bash
+# Full build test
+pnpm build
+
+# E2E with fresh packages
+pnpm dev:fresh
+pnpm www:cypress
+```
+
+## Common Issues & Solutions
+
+### "Module not found" in apps
+**Cause**: Package not built or outdated
+**Solution**: 
+```bash
+pnpm build:packages
+# or for specific package
+pnpm icons:build
+```
+
+### Storybook not showing new components
+**Cause**: Component not exported from package index
+**Solution**: Add export to `packages/cadence-core/src/index.ts`
+
+### Styling inconsistencies
+**Cause**: Outdated design tokens
+**Solution**:
+```bash
+pnpm tokens:build
+pnpm build:packages
+```
+
+### Changes not reflecting in apps
+**Cause**: Turbo cache or missing dependency build
+**Solution**:
+```bash
+# Clear cache and rebuild
+turbo clean
+pnpm build:packages
+pnpm dev:fresh
+```
+
+## File Locations Quick Reference
+
+### Configuration Files
+- Workspace: `pnpm-workspace.yaml`
+- Build system: `turbo.json`
+- Package manager: `package.json` (root)
+
+### App Entry Points
+- WWW: `apps/www/src/app/layout.tsx`
+- CMS: `apps/cms-sanity/sanity.config.ts`
+
+### Package Entry Points
+- Components: `packages/cadence-core/src/index.ts`
+- Icons: `packages/cadence-icons/src/index.ts`
+- Tokens: `packages/cadence-tokens/dist/`
+
+### Documentation
+- WWW specific: `apps/www/docs/`
+- Monorepo: `CLAUDE.md`, this file
+
+## Environment Setup
+
+### Prerequisites
+- Node.js 18+
+- pnpm 8.14.0+ (specified in package.json)
+
+### First-time Setup
+```bash
+# Install dependencies
+pnpm install
+
+# Build all packages
+pnpm build:packages
+
+# Start development
+pnpm dev
+```
+
+### Environment Variables
+- **WWW App**: See `apps/www/docs/setup/environment-variables.md`
+- **CMS**: Configured in Sanity Studio
+
+## AI Agent Guidelines
+
+### Before Making Changes
+1. Understand the dependency graph
+2. Build packages if modifying them
+3. Test in multiple apps if changing shared code
+
+### Decision Tree
+- **Styling/Design**: Modify tokens → rebuild packages
+- **New Component**: Add to cadence-core → build → use in apps  
+- **App Feature**: Work directly in app directory
+- **CMS Schema**: Modify cms-sanity schemas
+- **Icons**: Add to cadence-icons → build
+
+### Best Practices
+- Use turbo commands for builds (handles dependencies)
+- Test changes in Storybook before integrating
+- Build packages before testing apps
+- Check multiple apps for impact of package changes
+
+## Related Documentation
+
+- [CLAUDE.md](./CLAUDE.md) - Project architecture and overview
+- [WWW App Docs](./apps/www/docs/) - Specific to main website
+- [Turbo Documentation](https://turbo.build/repo/docs) - Build system reference

--- a/packages/cadence-core/docs/README.md
+++ b/packages/cadence-core/docs/README.md
@@ -1,0 +1,180 @@
+# Cadence Core Component Library Documentation
+
+This directory contains comprehensive documentation for the Cadence Core component library, part of the Downbeat Academy design system.
+
+## Documentation Structure
+
+### 📁 [setup/](./setup/)
+Development environment and build configuration guides
+- [development-guide.md](./setup/development-guide.md) - Local development setup and workflows
+- [storybook-guide.md](./setup/storybook-guide.md) - Storybook development and deployment
+
+### 📁 [testing/](./testing/)
+Testing strategies and component testing guides
+- [component-testing.md](./testing/component-testing.md) - Testing strategy and best practices
+- [storybook-testing.md](./testing/storybook-testing.md) - Visual regression and story testing
+
+### 📁 [implementation/](./implementation/)
+Implementation details and architectural decisions
+- [component-architecture.md](./implementation/component-architecture.md) - Component structure and patterns
+- [styling-system.md](./implementation/styling-system.md) - CSS modules and design token integration
+
+### 📁 [reference/](./reference/)
+Component API reference and quick guides
+- [components.md](./reference/components.md) - Complete component library reference
+- [design-tokens.md](./reference/design-tokens.md) - Available design tokens and usage
+- [commands.md](./reference/commands.md) - Build and development commands
+
+## Package Overview
+
+**Cadence Core** is the primary React component library for the Downbeat Academy design system, providing:
+
+- **UI Components**: Buttons, forms, cards, typography, layout components
+- **Design System Integration**: Built with cadence-tokens and cadence-icons
+- **TypeScript Support**: Full type definitions and IntelliSense
+- **CSS Modules**: Scoped styling with design token integration
+- **Storybook Documentation**: Interactive component playground
+- **Testing**: Vitest unit tests and visual regression testing
+
+## Quick Start
+
+### Installation
+```bash
+# In your app (if not using workspace)
+npm install cadence-core cadence-tokens cadence-icons
+
+# In monorepo
+pnpm install
+```
+
+### Basic Usage
+```tsx
+import { Button, Card, Text } from 'cadence-core'
+import 'cadence-core/styles.css'
+
+function App() {
+  return (
+    <Card>
+      <Text variant="heading">Welcome</Text>
+      <Button variant="primary">Get Started</Button>
+    </Card>
+  )
+}
+```
+
+### Development
+```bash
+# Start Storybook
+pnpm core:storybook
+
+# Run tests
+pnpm --filter=cadence-core test
+
+# Build package
+pnpm core:build
+```
+
+## Component Categories
+
+### Layout Components
+- **Flex** - Flexible layout container with design token spacing
+- **Grid** - CSS Grid layout with responsive breakpoints
+- **Card** - Content containers with elevation and spacing
+
+### Form Components
+- **Button** - Primary, secondary, and tertiary button variants
+- **Input** - Text inputs with validation states
+- **Textarea** - Multi-line text inputs
+- **Checkbox** - Single and grouped checkboxes
+- **Radio** - Radio buttons and radio cards
+- **Switch** - Toggle switches
+- **Field** - Form field wrapper with labels and validation
+
+### Typography
+- **Text** - Heading, body, and caption text with semantic variants
+- **List** - Ordered and unordered lists with design system styling
+
+### Feedback Components
+- **Badge** - Status indicators and labels
+- **Banner** - System messages and notifications
+
+### Brand Components
+- **Brand** - Logo components and brand elements
+
+## Storybook Integration
+
+Each component includes:
+- **Stories**: Interactive examples with controls
+- **Documentation**: MDX files with usage guidelines
+- **Tests**: Visual regression and interaction tests
+
+View components in Storybook:
+```bash
+pnpm core:storybook
+# Opens http://localhost:6006
+```
+
+## Dependencies
+
+### Workspace Dependencies
+- `cadence-tokens` - Design system tokens
+- `cadence-icons` - Icon library
+- `typeface-favorit` - Primary font family
+- `typeface-tiempos-text` - Secondary font family
+
+### External Dependencies
+- `@radix-ui/*` - Accessible primitive components
+- `classnames` - Conditional CSS class utilities
+
+## Development Workflow
+
+### Adding New Components
+1. Create component directory in `src/components/`
+2. Add component files (`index.ts`, `types.ts`, `[name].tsx`, `[name].module.css`)
+3. Create Storybook stories in `__docs__/` directory
+4. Add unit tests in `__test__/` directory
+5. Export from `src/index.ts`
+6. Build and test: `pnpm core:build && pnpm core:storybook`
+
+### Component Structure
+```
+component-name/
+├── index.ts              # Main export
+├── types.ts              # TypeScript definitions
+├── component-name.tsx    # Component implementation
+├── component-name.module.css # Styles
+├── __docs__/
+│   ├── component-name.stories.tsx
+│   └── component-name.mdx (optional)
+└── __test__/
+    └── component-name.test.tsx
+```
+
+## Design System Integration
+
+Components automatically inherit design tokens:
+- **Colors**: Semantic color palette from cadence-tokens
+- **Typography**: Font sizes, families, and line heights
+- **Spacing**: Consistent margin and padding scale
+- **Elevation**: Box shadow and border radius values
+
+## For AI Agents
+
+This component library is structured for efficient AI development:
+- **Consistent Patterns**: All components follow the same structure
+- **Type Safety**: Full TypeScript coverage with strict types
+- **Documentation**: Each component has stories and examples
+- **Testing**: Comprehensive test coverage for reliability
+- **Build System**: Automated building and publishing
+
+### Common Tasks
+- **Find Component**: Check `src/components/[name]/` directory
+- **See Examples**: View `__docs__/*.stories.tsx` files
+- **Check API**: Review `types.ts` files for props
+- **Test Changes**: Run `pnpm core:build && pnpm core:storybook`
+
+## Related Documentation
+
+- [Root agents.md](../../../agents.md) - Monorepo development guide
+- [WWW App Docs](../../../apps/www/docs/) - Implementation examples
+- [Storybook Deployment](https://cadence-storybook.vercel.app) - Live component library

--- a/packages/cadence-core/docs/reference/components.md
+++ b/packages/cadence-core/docs/reference/components.md
@@ -1,0 +1,376 @@
+# Component Reference
+
+Complete reference for all components in the Cadence Core library.
+
+## Layout Components
+
+### Flex
+Flexible layout container with design token spacing and alignment options.
+
+**Import:** `import { Flex } from 'cadence-core'`
+
+**Props:**
+- `direction?: 'row' | 'column' | 'row-reverse' | 'column-reverse'`
+- `align?: 'start' | 'center' | 'end' | 'stretch' | 'baseline'`
+- `justify?: 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly'`
+- `gap?: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'`
+- `wrap?: boolean`
+
+**Example:**
+```tsx
+<Flex direction="column" align="center" gap="md">
+  <Text>Header</Text>
+  <Button>Action</Button>
+</Flex>
+```
+
+### Grid
+CSS Grid layout with responsive breakpoints and design system integration.
+
+**Import:** `import { Grid, GridItem } from 'cadence-core'`
+
+**Grid Props:**
+- `columns?: number | { sm?: number, md?: number, lg?: number }`
+- `gap?: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'`
+- `rows?: number`
+
+**GridItem Props:**
+- `colSpan?: number | { sm?: number, md?: number, lg?: number }`
+- `rowSpan?: number`
+
+**Example:**
+```tsx
+<Grid columns={{ sm: 1, md: 2, lg: 3 }} gap="md">
+  <GridItem colSpan={{ sm: 1, md: 2 }}>
+    <Card>Featured Content</Card>
+  </GridItem>
+  <GridItem>
+    <Card>Regular Content</Card>
+  </GridItem>
+</Grid>
+```
+
+### Card
+Content container with elevation and spacing options.
+
+**Import:** `import { Card, CardContent, CardImage } from 'cadence-core'`
+
+**Card Props:**
+- `variant?: 'default' | 'outlined' | 'elevated'`
+- `padding?: 'none' | 'sm' | 'md' | 'lg'`
+
+**Example:**
+```tsx
+<Card variant="elevated" padding="md">
+  <CardImage src="/image.jpg" alt="Description" />
+  <CardContent>
+    <Text variant="heading">Card Title</Text>
+    <Text>Card description content.</Text>
+  </CardContent>
+</Card>
+```
+
+## Form Components
+
+### Button
+Primary interactive element with multiple variants and states.
+
+**Import:** `import { Button } from 'cadence-core'`
+
+**Props:**
+- `variant?: 'primary' | 'secondary' | 'tertiary' | 'ghost' | 'destructive'`
+- `size?: 'sm' | 'md' | 'lg'`
+- `disabled?: boolean`
+- `loading?: boolean`
+- `fullWidth?: boolean`
+- `type?: 'button' | 'submit' | 'reset'`
+
+**Example:**
+```tsx
+<Button variant="primary" size="lg" onClick={handleClick}>
+  Primary Action
+</Button>
+```
+
+### Input
+Text input component with validation states and accessibility features.
+
+**Import:** `import { Input } from 'cadence-core'`
+
+**Props:**
+- `type?: 'text' | 'email' | 'password' | 'number' | 'tel' | 'url'`
+- `placeholder?: string`
+- `disabled?: boolean`
+- `error?: boolean`
+- `required?: boolean`
+- `fullWidth?: boolean`
+
+**Example:**
+```tsx
+<Input
+  type="email"
+  placeholder="Enter your email"
+  error={hasError}
+  required
+/>
+```
+
+### Textarea
+Multi-line text input with auto-resize capability.
+
+**Import:** `import { Textarea } from 'cadence-core'`
+
+**Props:**
+- `placeholder?: string`
+- `disabled?: boolean`
+- `error?: boolean`
+- `required?: boolean`
+- `rows?: number`
+- `resize?: 'none' | 'vertical' | 'horizontal' | 'both'`
+
+### Checkbox
+Single checkbox or checkbox group with custom styling.
+
+**Import:** `import { Checkbox } from 'cadence-core'`
+
+**Props:**
+- `checked?: boolean`
+- `disabled?: boolean`
+- `error?: boolean`
+- `indeterminate?: boolean`
+- `label?: string`
+
+**Example:**
+```tsx
+<Checkbox
+  checked={isChecked}
+  onChange={setIsChecked}
+  label="Accept terms and conditions"
+/>
+```
+
+### Radio
+Radio button component with group functionality.
+
+**Import:** `import { Radio } from 'cadence-core'`
+
+**Props:**
+- `value: string`
+- `checked?: boolean`
+- `disabled?: boolean`
+- `name?: string`
+- `label?: string`
+
+### RadioCard
+Card-style radio buttons for enhanced visual selection.
+
+**Import:** `import { RadioCardGroup, RadioCardItem } from 'cadence-core'`
+
+**RadioCardGroup Props:**
+- `value?: string`
+- `onChange?: (value: string) => void`
+- `name?: string`
+
+**RadioCardItem Props:**
+- `value: string`
+- `disabled?: boolean`
+- `children: ReactNode`
+
+### Switch
+Toggle switch for binary states.
+
+**Import:** `import { Switch } from 'cadence-core'`
+
+**Props:**
+- `checked?: boolean`
+- `disabled?: boolean`
+- `size?: 'sm' | 'md' | 'lg'`
+- `label?: string`
+
+### Field
+Form field wrapper providing labels, validation, and help text.
+
+**Import:** `import { Field, Label, HelperText, ValidationMessage } from 'cadence-core'`
+
+**Field Props:**
+- `error?: boolean`
+- `required?: boolean`
+- `children: ReactNode`
+
+**Example:**
+```tsx
+<Field error={hasError} required>
+  <Label>Email Address</Label>
+  <Input type="email" error={hasError} />
+  <HelperText>We'll never share your email</HelperText>
+  {hasError && <ValidationMessage>Please enter a valid email</ValidationMessage>}
+</Field>
+```
+
+## Typography Components
+
+### Text
+Semantic text component with design system typography scale.
+
+**Import:** `import { Text } from 'cadence-core'`
+
+**Props:**
+- `variant?: 'display' | 'heading' | 'subheading' | 'body' | 'caption' | 'overline'`
+- `size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl'`
+- `weight?: 'light' | 'regular' | 'medium' | 'semibold' | 'bold'`
+- `color?: 'primary' | 'secondary' | 'muted' | 'success' | 'warning' | 'error'`
+- `align?: 'left' | 'center' | 'right' | 'justify'`
+
+**Example:**
+```tsx
+<Text variant="heading" size="xl" weight="bold">
+  Section Headline
+</Text>
+<Text variant="body" color="muted">
+  Supporting description text.
+</Text>
+```
+
+### List
+Styled ordered and unordered lists.
+
+**Import:** `import { List } from 'cadence-core'`
+
+**Props:**
+- `type?: 'unordered' | 'ordered'`
+- `variant?: 'default' | 'compact'`
+- `children: ReactNode`
+
+**Example:**
+```tsx
+<List type="unordered">
+  <li>First item</li>
+  <li>Second item</li>
+  <li>Third item</li>
+</List>
+```
+
+## Feedback Components
+
+### Badge
+Small status indicators and labels.
+
+**Import:** `import { Badge } from 'cadence-core'`
+
+**Props:**
+- `variant?: 'default' | 'primary' | 'secondary' | 'success' | 'warning' | 'error'`
+- `size?: 'sm' | 'md' | 'lg'`
+- `dot?: boolean`
+- `children: ReactNode`
+
+**Example:**
+```tsx
+<Badge variant="success">Active</Badge>
+<Badge variant="warning" dot>Pending</Badge>
+```
+
+### Banner
+System-wide notifications and messages.
+
+**Import:** `import { Banner, BannerContent, BannerActions } from 'cadence-core'`
+
+**Banner Props:**
+- `variant?: 'info' | 'success' | 'warning' | 'error'`
+- `dismissible?: boolean`
+- `onDismiss?: () => void`
+
+**Example:**
+```tsx
+<Banner variant="info" dismissible onDismiss={handleDismiss}>
+  <BannerContent>
+    <Text weight="medium">New feature available</Text>
+    <Text size="sm">Check out our latest updates.</Text>
+  </BannerContent>
+  <BannerActions>
+    <Button variant="tertiary" size="sm">Learn More</Button>
+  </BannerActions>
+</Banner>
+```
+
+## Brand Components
+
+### Brand
+Logo and brand element components.
+
+**Import:** `import { LogoSymbol, LogoText, LogoLockup } from 'cadence-core'`
+
+**Props:**
+- `size?: 'sm' | 'md' | 'lg' | 'xl'`
+- `color?: 'primary' | 'white' | 'black'`
+
+**Example:**
+```tsx
+<LogoLockup size="lg" color="primary" />
+<LogoSymbol size="md" color="white" />
+```
+
+## Form Layout Components
+
+### HorizontalWrapper
+Layout wrapper for horizontal form arrangements.
+
+**Import:** `import { HorizontalWrapper } from 'cadence-core'`
+
+**Props:**
+- `gap?: 'sm' | 'md' | 'lg'`
+- `align?: 'start' | 'center' | 'end'`
+
+### CheckboxCard
+Card-style checkbox for enhanced selection interfaces.
+
+**Import:** `import { CheckboxCardGroup, CheckboxCardItem } from 'cadence-core'`
+
+## Styling Guidelines
+
+### CSS Modules
+All components use CSS modules for scoped styling:
+```tsx
+// Component styles are automatically scoped
+import styles from './button.module.css'
+
+<button className={styles.button}>Button</button>
+```
+
+### Design Tokens
+Components automatically use design tokens from cadence-tokens:
+- **Colors**: `var(--color-primary-500)`
+- **Spacing**: `var(--space-md)`
+- **Typography**: `var(--font-size-lg)`
+- **Radii**: `var(--radius-md)`
+
+### Custom Styling
+Override component styles using CSS custom properties:
+```css
+.custom-button {
+  --button-background: var(--color-brand-500);
+  --button-text: var(--color-white);
+}
+```
+
+## Accessibility
+
+All components follow WCAG 2.1 AA guidelines:
+- **Keyboard Navigation**: Full keyboard support
+- **Screen Readers**: Proper ARIA labels and descriptions  
+- **Focus Management**: Visible focus indicators
+- **Color Contrast**: Meets contrast ratio requirements
+- **Semantic HTML**: Uses appropriate HTML elements
+
+## TypeScript Support
+
+Full TypeScript coverage with:
+- **Prop Types**: Strict typing for all component props
+- **Event Handlers**: Typed event callbacks
+- **Ref Support**: forwardRef support where appropriate
+- **Generic Components**: Type-safe generic props
+
+## Related Documentation
+
+- [Development Guide](../setup/development-guide.md) - Local development setup
+- [Component Architecture](../implementation/component-architecture.md) - Implementation details
+- [Storybook Guide](../setup/storybook-guide.md) - Interactive documentation

--- a/packages/cadence-core/docs/setup/development-guide.md
+++ b/packages/cadence-core/docs/setup/development-guide.md
@@ -1,0 +1,490 @@
+# Development Guide - Cadence Core
+
+This guide covers local development setup and workflows for the Cadence Core component library.
+
+## Prerequisites
+
+- Node.js 18+
+- pnpm 8.14.0+
+- Basic knowledge of React and TypeScript
+
+## Quick Start
+
+### Initial Setup
+```bash
+# From monorepo root
+pnpm install
+
+# Build dependencies first
+pnpm tokens:build
+pnpm icons:build
+
+# Start Storybook for development
+pnpm core:storybook
+# Opens http://localhost:6006
+```
+
+### Development Workflow
+```bash
+# Make component changes
+# Storybook will hot-reload automatically
+
+# Run tests
+pnpm --filter=cadence-core test
+
+# Build package
+pnpm core:build
+
+# Test in consuming app
+cd ../../apps/www
+pnpm dev
+```
+
+## Project Structure
+
+```
+cadence-core/
+├── src/
+│   ├── components/          # All React components
+│   │   ├── badge/
+│   │   │   ├── index.ts    # Main export
+│   │   │   ├── types.ts    # TypeScript definitions
+│   │   │   ├── badge.tsx   # Component implementation
+│   │   │   ├── badge.module.css # Scoped styles
+│   │   │   ├── __docs__/
+│   │   │   │   ├── badge.stories.tsx # Storybook stories
+│   │   │   │   └── badge.mdx         # Documentation (optional)
+│   │   │   └── __test__/
+│   │   │       └── badge.test.tsx    # Unit tests
+│   │   └── [other-components]/
+│   ├── index.ts            # Package exports
+│   └── global.d.ts         # Global type definitions
+├── docs/                   # Package documentation
+├── dist/                   # Build output
+├── storybook-static/       # Storybook build output
+├── package.json
+├── rollup.config.js        # Build configuration
+├── vite.config.ts          # Vite/Vitest configuration
+└── tsconfig.json           # TypeScript configuration
+```
+
+## Component Development
+
+### Creating a New Component
+
+1. **Create component directory:**
+```bash
+mkdir src/components/my-component
+cd src/components/my-component
+```
+
+2. **Create basic files:**
+
+**index.ts** (Main export):
+```typescript
+export { MyComponent } from './my-component'
+export type { MyComponentProps } from './types'
+```
+
+**types.ts** (Type definitions):
+```typescript
+import { ReactNode } from 'react'
+
+export interface MyComponentProps {
+  children: ReactNode
+  variant?: 'primary' | 'secondary'
+  size?: 'sm' | 'md' | 'lg'
+  disabled?: boolean
+  onClick?: () => void
+  className?: string
+}
+```
+
+**my-component.tsx** (Implementation):
+```typescript
+import { forwardRef } from 'react'
+import classNames from 'classnames'
+import { MyComponentProps } from './types'
+import styles from './my-component.module.css'
+
+export const MyComponent = forwardRef<HTMLButtonElement, MyComponentProps>(
+  ({ children, variant = 'primary', size = 'md', disabled, onClick, className }, ref) => {
+    const classes = classNames(
+      styles.component,
+      styles[variant],
+      styles[size],
+      { [styles.disabled]: disabled },
+      className
+    )
+
+    return (
+      <button
+        ref={ref}
+        className={classes}
+        disabled={disabled}
+        onClick={onClick}
+        type="button"
+      >
+        {children}
+      </button>
+    )
+  }
+)
+
+MyComponent.displayName = 'MyComponent'
+```
+
+**my-component.module.css** (Styles):
+```css
+.component {
+  /* Base styles using design tokens */
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-md);
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all var(--transition-fast) ease;
+}
+
+.primary {
+  background-color: var(--color-primary-500);
+  color: var(--color-white);
+}
+
+.primary:hover {
+  background-color: var(--color-primary-600);
+}
+
+.secondary {
+  background-color: var(--color-surface-100);
+  color: var(--color-foreground-900);
+  border-color: var(--color-border-200);
+}
+
+.sm {
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-sm);
+}
+
+.md {
+  padding: var(--space-sm) var(--space-md);
+}
+
+.lg {
+  padding: var(--space-md) var(--space-lg);
+  font-size: var(--font-size-lg);
+}
+
+.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+```
+
+3. **Create Storybook story:**
+
+**__docs__/my-component.stories.tsx**:
+```typescript
+import type { Meta, StoryObj } from '@storybook/react'
+import { MyComponent } from '../my-component'
+
+const meta: Meta<typeof MyComponent> = {
+  title: 'Components/MyComponent',
+  component: MyComponent,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+    children: 'Button',
+  },
+}
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+    children: 'Button',
+  },
+}
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+    children: 'Small Button',
+  },
+}
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+    children: 'Large Button',
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    children: 'Disabled Button',
+  },
+}
+```
+
+4. **Create unit test:**
+
+**__test__/my-component.test.tsx**:
+```typescript
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MyComponent } from '../my-component'
+
+describe('MyComponent', () => {
+  it('renders with default props', () => {
+    render(<MyComponent>Test Button</MyComponent>)
+    expect(screen.getByRole('button')).toBeInTheDocument()
+    expect(screen.getByText('Test Button')).toBeInTheDocument()
+  })
+
+  it('applies variant classes correctly', () => {
+    render(<MyComponent variant="secondary">Button</MyComponent>)
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('secondary')
+  })
+
+  it('applies size classes correctly', () => {
+    render(<MyComponent size="lg">Button</MyComponent>)
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('lg')
+  })
+
+  it('handles click events', () => {
+    const handleClick = vi.fn()
+    render(<MyComponent onClick={handleClick}>Button</MyComponent>)
+    
+    fireEvent.click(screen.getByRole('button'))
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the button when disabled prop is true', () => {
+    render(<MyComponent disabled>Button</MyComponent>)
+    const button = screen.getByRole('button')
+    expect(button).toBeDisabled()
+    expect(button).toHaveClass('disabled')
+  })
+})
+```
+
+5. **Export from package:**
+
+Add to `src/index.ts`:
+```typescript
+export { MyComponent } from './components/my-component'
+export type { MyComponentProps } from './components/my-component'
+```
+
+6. **Test the component:**
+```bash
+# Run tests
+pnpm test
+
+# View in Storybook
+pnpm core:storybook
+
+# Build package
+pnpm core:build
+```
+
+## Design Token Integration
+
+### Using Design Tokens in CSS
+```css
+.component {
+  /* Colors */
+  color: var(--color-foreground-900);
+  background-color: var(--color-surface-100);
+  border-color: var(--color-border-200);
+  
+  /* Spacing */
+  padding: var(--space-md);
+  margin: var(--space-sm);
+  
+  /* Typography */
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-md);
+  font-weight: var(--font-weight-medium);
+  
+  /* Border radius */
+  border-radius: var(--radius-md);
+  
+  /* Elevation */
+  box-shadow: var(--elevation-sm);
+  
+  /* Animation */
+  transition: all var(--transition-fast) ease;
+}
+```
+
+### Available Token Categories
+- **Colors**: `--color-[category]-[weight]`
+- **Spacing**: `--space-[size]`
+- **Typography**: `--font-[property]-[variant]`
+- **Radii**: `--radius-[size]`
+- **Elevation**: `--elevation-[level]`
+- **Transitions**: `--transition-[speed]`
+
+## Testing Strategy
+
+### Unit Tests with Vitest
+```bash
+# Run tests
+pnpm test
+
+# Run tests in watch mode
+pnpm test --watch
+
+# Run tests with coverage
+pnpm test --coverage
+```
+
+### Testing Best Practices
+1. **Test component behavior, not implementation**
+2. **Use accessible queries**: `getByRole`, `getByLabelText`, etc.
+3. **Test user interactions**: clicks, keyboard navigation
+4. **Test accessibility**: screen reader support, focus management
+5. **Mock external dependencies**: icons, tokens
+
+### Example Test Patterns
+```typescript
+// Testing component rendering
+it('renders with correct accessibility attributes', () => {
+  render(<Button aria-label="Close dialog">×</Button>)
+  expect(screen.getByRole('button')).toHaveAccessibleName('Close dialog')
+})
+
+// Testing variants
+it.each([
+  ['primary', 'primary'],
+  ['secondary', 'secondary'],
+  ['tertiary', 'tertiary'],
+])('applies %s variant class', (variant, expectedClass) => {
+  render(<Button variant={variant}>Button</Button>)
+  expect(screen.getByRole('button')).toHaveClass(expectedClass)
+})
+
+// Testing interactions
+it('calls onClick when clicked', async () => {
+  const user = userEvent.setup()
+  const handleClick = vi.fn()
+  
+  render(<Button onClick={handleClick}>Button</Button>)
+  await user.click(screen.getByRole('button'))
+  
+  expect(handleClick).toHaveBeenCalledTimes(1)
+})
+```
+
+## Build System
+
+### Development Build
+```bash
+# Build for development (includes source maps)
+pnpm build
+```
+
+### Production Build
+```bash
+# Clean previous build
+pnpm clean
+
+# Full production build
+pnpm build
+```
+
+### Build Outputs
+- `dist/index.esm.js` - ES modules
+- `dist/index.cjs.js` - CommonJS
+- `dist/index.d.ts` - TypeScript definitions
+- `dist/cadence-core.min.css` - Compiled CSS
+
+## Storybook Development
+
+### Starting Storybook
+```bash
+# Development server
+pnpm core:storybook
+
+# Build static Storybook
+pnpm core:build-storybook
+```
+
+### Story Best Practices
+1. **Use controls** for interactive props
+2. **Document component usage** with descriptions
+3. **Show multiple variants** in different stories
+4. **Include edge cases**: empty states, long content
+5. **Add accessibility testing** with a11y addon
+
+## Dependencies
+
+### Workspace Dependencies
+- `cadence-tokens` - Design system tokens (required)
+- `cadence-icons` - Icon library (required)
+- `typeface-favorit` - Primary font
+- `typeface-tiempos-text` - Secondary font
+
+### External Dependencies
+- `@radix-ui/*` - Accessible primitives
+- `classnames` - CSS class utilities
+- `react` & `react-dom` - Peer dependencies
+
+### Development Dependencies
+- `typescript` - Type checking
+- `rollup` - Bundling
+- `vitest` - Testing framework
+- `storybook` - Component documentation
+
+## Common Issues
+
+### Component not showing in Storybook
+1. Check that the story is properly exported
+2. Ensure component is exported from `src/index.ts`
+3. Restart Storybook server
+
+### Styles not applying
+1. Verify CSS modules are imported correctly
+2. Check that design tokens are available
+3. Ensure cadence-tokens is built: `pnpm tokens:build`
+
+### TypeScript errors
+1. Run type checking: `pnpm tsc --noEmit`
+2. Check that all dependencies have types
+3. Update `tsconfig.json` if needed
+
+### Tests failing
+1. Check test imports match exports
+2. Ensure test environment is set up correctly
+3. Mock external dependencies properly
+
+## Related Documentation
+
+- [Component Reference](../reference/components.md) - Complete API documentation
+- [Storybook Guide](./storybook-guide.md) - Interactive documentation setup
+- [Component Architecture](../implementation/component-architecture.md) - Design patterns

--- a/packages/cadence-icons/docs/README.md
+++ b/packages/cadence-icons/docs/README.md
@@ -1,0 +1,355 @@
+# Cadence Icons Documentation
+
+This directory contains comprehensive documentation for the Cadence Icons library, part of the Downbeat Academy design system.
+
+## Documentation Structure
+
+### 📁 [setup/](./setup/)
+Development environment and build configuration guides
+- [development-guide.md](./setup/development-guide.md) - Local development setup and icon creation workflow
+
+### 📁 [reference/](./reference/)
+Icon library reference and usage guides  
+- [icons.md](./reference/icons.md) - Complete icon library reference with examples
+- [usage-guide.md](./reference/usage-guide.md) - Implementation patterns and best practices
+
+## Package Overview
+
+**Cadence Icons** is the icon library for the Downbeat Academy design system, providing:
+
+- **SVG Icons**: Scalable vector icons optimized for web
+- **React Components**: Pre-built React components for each icon
+- **TypeScript Support**: Full type definitions and IntelliSense
+- **Consistent Styling**: Icons follow design system principles
+- **Tree Shaking**: Import only the icons you need
+- **Customizable**: Support for size, color, and accessibility props
+
+## Quick Start
+
+### Installation
+```bash
+# In your app (if not using workspace)
+npm install cadence-icons
+
+# In monorepo (already available)
+pnpm install
+```
+
+### Basic Usage
+```tsx
+import { PlayFill, PauseFill, Heart } from 'cadence-icons'
+
+function AudioControls() {
+  return (
+    <div>
+      <PlayFill size={24} color="currentColor" />
+      <PauseFill size={24} color="currentColor" />
+      <Heart size={20} color="red" />
+    </div>
+  )
+}
+```
+
+### Development
+```bash
+# Start development server (icon viewer)
+pnpm icons:dev
+
+# Add new icon (add SVG to src/assets/)
+# Then rebuild components
+pnpm icons:build
+
+# Build package
+pnpm --filter=cadence-icons build
+```
+
+## Available Icons
+
+### Audio & Media
+- **PlayFill**, **PlayOutline** - Play controls
+- **PauseFill**, **PauseOutline** - Pause controls  
+- **StopFill**, **StopOutline** - Stop controls
+- **NextFill**, **NextOutline** - Next track
+- **PreviousFill**, **PreviousOutline** - Previous track
+- **FastForwardFill**, **FastForwardOutline** - Fast forward
+- **RewindFill**, **RewindOutline** - Rewind
+- **Volume**, **VolumeQuiet**, **VolumeMute**, **VolumeNone** - Volume controls
+- **Microphone**, **MicrophoneAlt**, **MicrophoneOff** - Audio input
+- **Headphones** - Audio output
+- **Music**, **MusicOff** - Music indicators
+- **Playlist** - Playlist management
+
+### Navigation & UI
+- **ChevronUp**, **ChevronDown**, **ChevronLeft**, **ChevronRight** - Directional
+- **ChevronsUp**, **ChevronsLeft**, **ChevronsRight** - Double chevrons
+- **CaretUp**, **CaretDown**, **CaretLeft**, **CaretRight** - Small arrows
+- **ArrowBack** - Back navigation
+- **ArrowBar[Direction]** - Arrow with bar indicators
+- **ArrowBarTo[Direction]** - Arrow to edge indicators
+- **OpenNewWindow** - External links
+
+### Actions & Controls
+- **Check** - Confirmations
+- **X** - Close/cancel
+- **Plus** - Add/create
+- **Minus** - Remove/subtract
+- **Download** - File downloads
+- **Refresh**, **Reload** - Refresh actions
+- **ArrowsMaximize**, **ArrowsMinimize** - Size controls
+- **ArrowsMove**, **ArrowsShuffle**, **ArrowsSort** - Organization
+
+### Status & Feedback
+- **CheckCircleOutline** - Success states
+- **ErrorCircleOutline**, **XCircleOutline** - Error states  
+- **AlertCircleOutline**, **AlertTriangleOutline** - Warnings
+- **InfoCircleOutline**, **QuestionCircleOutline** - Information
+- **WarningTriangleOutline** - Warnings
+- **MinusCircleOutline**, **PlusCircleOutline** - Quantity controls
+
+### Interface Elements
+- **Dot**, **DotFilled** - Status indicators
+- **Repeat** - Loop/repeat indicators
+
+### Social & External
+- **Facebook**, **Instagram**, **Twitter**, **Youtube**, **Tiktok** - Social platforms
+
+## Icon Properties
+
+All icons support these common props:
+
+```typescript
+interface IconProps {
+  size?: number | string    // Default: 24
+  color?: string           // Default: 'currentColor'  
+  className?: string       // Additional CSS classes
+  'aria-label'?: string    // Accessibility label
+  'aria-hidden'?: boolean  // Hide from screen readers
+  role?: string           // ARIA role (default: 'img')
+}
+```
+
+## Usage Patterns
+
+### Basic Icon
+```tsx
+import { PlayFill } from 'cadence-icons'
+
+<PlayFill size={32} color="#007AFF" />
+```
+
+### With Accessibility
+```tsx
+import { Download } from 'cadence-icons'
+
+<Download 
+  size={20} 
+  aria-label="Download file" 
+  role="img"
+/>
+```
+
+### In Buttons
+```tsx
+import { PlusCircleOutline } from 'cadence-icons'
+import { Button } from 'cadence-core'
+
+<Button>
+  <PlusCircleOutline size={16} />
+  Add Item
+</Button>
+```
+
+### Custom Styling
+```tsx
+import { Heart } from 'cadence-icons'
+
+<Heart 
+  size={24}
+  className="favorite-icon"
+  style={{ color: isLiked ? 'red' : 'gray' }}
+/>
+```
+
+## Icon Development Workflow
+
+### Adding New Icons
+
+1. **Add SVG file** to `src/assets/`
+2. **Name consistently**: `kebab-case.svg`
+3. **Optimize SVG**: Remove unnecessary attributes, ensure viewBox is `0 0 24 24`
+4. **Generate components**: `pnpm icons:build`
+5. **Test icon**: `pnpm icons:dev`
+6. **Build package**: `pnpm build`
+
+### SVG Optimization Guidelines
+
+```svg
+<!-- Good: Clean, optimized SVG -->
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 5v14l11-7z" fill="currentColor"/>
+</svg>
+
+<!-- Bad: Complex SVG with unnecessary attributes -->
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <g id="Layer_1" transform="translate(0.000000,0.000000)" fill="#000000">
+    <path d="M8 5v14l11-7z"/>
+  </g>
+</svg>
+```
+
+### Component Generation
+
+Icons are automatically generated as React components using SVGR:
+
+```typescript
+// Generated component structure
+import { forwardRef } from 'react'
+import type { IconProps } from '../types'
+
+export const PlayFill = forwardRef<SVGSVGElement, IconProps>(
+  ({ size = 24, color = 'currentColor', ...props }, ref) => (
+    <svg
+      ref={ref}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      {...props}
+    >
+      <path d="M8 5v14l11-7z" fill={color} />
+    </svg>
+  )
+)
+
+PlayFill.displayName = 'PlayFill'
+```
+
+## Design Guidelines
+
+### Icon Design Principles
+- **24x24 Grid**: All icons fit within a 24x24 pixel grid
+- **Consistent Weight**: 2px stroke width for outlined icons
+- **Simple Shapes**: Clear, recognizable forms
+- **Scalable**: Look good from 16px to 48px+
+- **Accessible**: Sufficient contrast and clear shapes
+
+### Naming Conventions
+- **Descriptive**: Clear purpose (Play, Pause, Download)
+- **Variant Suffix**: Fill, Outline, Alt versions
+- **Consistent**: Follow existing patterns
+- **PascalCase**: Component names in PascalCase
+
+### Icon Variants
+- **Fill**: Solid icons for active states
+- **Outline**: Stroke-based icons for inactive states
+- **Alt**: Alternative versions of same concept
+
+## Build System
+
+### Development Build
+```bash
+# Clean generated components
+pnpm clean
+
+# Generate components from SVGs
+pnpm svgr
+
+# Build package
+pnpm build
+```
+
+### Scripts Overview
+- `pnpm ensure-icons` - Verify all SVGs have components
+- `pnpm clean` - Remove generated components
+- `pnpm svgr` - Generate React components from SVGs
+- `pnpm icons:build` - Clean and regenerate components
+- `pnpm build` - Build package for distribution
+
+## Integration with Design System
+
+### With Cadence Core Components
+```tsx
+import { Button } from 'cadence-core'
+import { Download } from 'cadence-icons'
+
+<Button variant="primary">
+  <Download size={16} />
+  Download Report
+</Button>
+```
+
+### With Design Tokens
+```css
+.icon-button {
+  color: var(--color-primary-500);
+  background: var(--color-surface-100);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm);
+}
+```
+
+## Accessibility
+
+### Screen Reader Support
+```tsx
+// Decorative icon (hidden from screen readers)
+<Heart aria-hidden="true" />
+
+// Functional icon (with label)
+<Download aria-label="Download file" role="img" />
+
+// In button context (button provides label)
+<button aria-label="Like this post">
+  <Heart aria-hidden="true" />
+</button>
+```
+
+### Color and Contrast
+- Icons inherit text color by default (`currentColor`)
+- Ensure sufficient contrast (4.5:1 for normal text)
+- Don't rely on color alone to convey information
+
+## Performance
+
+### Tree Shaking
+```tsx
+// Good: Import only needed icons
+import { PlayFill, PauseFill } from 'cadence-icons'
+
+// Bad: Import entire library
+import * as Icons from 'cadence-icons'
+```
+
+### Bundle Size
+- Individual icons are small (~1-2KB each)
+- Only imported icons are included in bundle
+- SVG format provides optimal compression
+
+## For AI Agents
+
+When working with cadence-icons:
+
+### Finding Icons
+1. Check `src/assets/` for available SVG files
+2. Look at generated components in `src/components/`
+3. Reference the icon viewer at `pnpm icons:dev`
+
+### Adding Icons
+1. Add optimized SVG to `src/assets/`
+2. Run `pnpm icons:build` to generate component
+3. Export from `src/index.ts` if not auto-exported
+4. Test with `pnpm icons:dev`
+
+### Common Tasks
+- **New Icon**: Add SVG → generate → build → test
+- **Update Icon**: Replace SVG → regenerate → test
+- **Find Usage**: Search codebase for icon component name
+
+## Related Documentation
+
+- [Usage Guide](./reference/usage-guide.md) - Implementation patterns
+- [Icon Reference](./reference/icons.md) - Complete icon list
+- [Development Guide](./setup/development-guide.md) - Development workflows
+- [Root agents.md](../../../agents.md) - Monorepo development guide


### PR DESCRIPTION
- Add root-level agents.md for monorepo operations and workspace navigation
- Create cadence-core/docs with complete component library documentation
  - Development guide with step-by-step component creation workflow
  - Component API reference with props, examples, and usage patterns
  - Testing strategies and design token integration
- Add cadence-icons/docs with icon library documentation and workflows
- Establish consistent docs structure across packages (setup/, testing/, implementation/, reference/)
- Provide AI-friendly documentation with clear hierarchy and cross-references

Complements existing apps/www/docs structure to create comprehensive documentation ecosystem for both human developers and AI agents.

🤖 Generated with [Claude Code](https://claude.ai/code)