### PR TITLE
docs: Update README with monorepo structure and development guide

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
 # Downbeat Academy
 
-This is the monorepo for all Downbeat Academy projects, managed with Yarn
-workspaces.
+This is the monorepo for all Downbeat Academy projects, managed with pnpm
+workspaces and Turbo.
 
 # Contents
 
@@ -10,18 +10,41 @@ workspaces.
 ### `www`
 
 - Main Downbeat Academy website
-- Built with Next.js and Cadence Design System components and tokens.
-- View at [downbeatacademy.com](https://downbeatacademy.com).
+- Built with Next.js and Cadence Design System components and tokens
+- View at [downbeatacademy.com](https://downbeatacademy.com)
 
 ### `cms-sanity`
 
 - Instance of Sanity Studio for managing content on `www`
 - Primary CMS for all educational content and resources
 
+### `auth`
+
+- Centralized authentication service for all Downbeat Academy apps
+- Built with Next.js, better-auth, and Drizzle ORM
+- OAuth 2.1 provider for federated authentication across apps
+- Includes admin dashboard for user and session management
+
+### `cadence-links`
+
+- URL shortener service for Downbeat Academy
+- Built with Next.js and Drizzle ORM
+
 ## Packages
 
 These are the packages used to build and maintain Downbeat Academy applications,
-including the Cadence Design System
+including the Cadence Design System.
+
+### `cadence-core`
+
+- Core component library for the Cadence Design System
+- Built with React and Radix UI primitives
+- Includes Storybook for component development and documentation
+
+### `cadence-core-web-components`
+
+- Web Components version of the Cadence Design System
+- Built with Lit
 
 ### `cadence-icons`
 
@@ -32,6 +55,15 @@ including the Cadence Design System
 - Global and semantic tokens for the Cadence Design System
 - Managed and built with `style-dictionary`
 
+### `auth-permissions`
+
+- Shared RBAC permissions, roles, and access control utilities
+- Used across `www`, `auth`, and `cadence-links`
+
+### `email`
+
+- Email templates built with React Email
+
 ### `typeface-favorit`
 
 - Font dependencies for ABC Favorit
@@ -40,7 +72,35 @@ including the Cadence Design System
 
 - Font dependencies for Tiempos Text
 
+## Development
+
+```bash
+# Run all apps in development
+pnpm dev
+
+# Run specific apps
+pnpm www:dev         # Main website
+pnpm cms:dev         # Sanity CMS
+pnpm auth:dev        # Auth service
+pnpm links:dev       # URL shortener
+pnpm email:dev       # Email templates
+
+# Build
+pnpm build           # Build all packages and apps
+
+# Testing
+pnpm test            # Run all tests
+pnpm lint            # Lint all packages
+pnpm format          # Format with Prettier
+
+# Storybook
+pnpm core:storybook  # React component library
+pnpm wc:storybook    # Web components library
+```
+
 ## Other notes
 
-- Versioning manged with changesets
+- Versioning managed with changesets
+- Build orchestration with Turbo
+- Secrets managed with Infisical
 - _Most_ apps and packages (if applicable) deploy to Vercel


### PR DESCRIPTION
# Pull Request Description

## What does this PR do?
Updates the README to reflect the current monorepo structure and tooling. Changes include:
- Updates package manager from Yarn to pnpm with Turbo for build orchestration
- Documents new applications: `auth` (authentication service), `cadence-links` (URL shortener)
- Documents new packages: `cadence-core`, `cadence-core-web-components`, `auth-permissions`, `email`
- Adds comprehensive development guide with common commands for running apps, building, testing, and Storybook
- Updates infrastructure notes to include Turbo and Infisical for secrets management
- Fixes minor typos and formatting inconsistencies

## Related Issues
N/A

## Type of Change
- [x] Documentation

## Testing
N/A

## Checklist
- [x] I have updated documentation

## Notes
This is a documentation-only change that brings the README in sync with the current monorepo architecture and development workflow. No code changes are included.

https://claude.ai/code/session_01KUyDNpW22jQyPAgv84CCJV