### PR TITLE
fix: resolve all 42 React Compiler lint warnings from eslint-config-n…

### DIFF
--- a/.changeset/fix-react-compiler-warnings.md
+++ b/.changeset/fix-react-compiler-warnings.md
@@ -1,0 +1,10 @@
+---
+"www": patch
+---
+
+Resolve all 42 React Compiler lint warnings introduced by eslint-config-next 16.2.
+
+- `react-hooks/error-boundaries`: remove try/catch wrappers around JSX in server page route functions; data fetching errors now propagate naturally via Next.js error handling
+- `react-hooks/set-state-in-effect`: replace setState-in-effect patterns with `useMemo`, during-render state resets, and `useSyncExternalStore` for browser API subscriptions (window resize, mount detection)
+- `react-hooks/immutability`: replace `window.location.href` assignment with `window.location.assign()` in header navigation
+- `react-hooks/incompatible-library`: replace react-hook-form `watch()` with `useWatch()` and derive computed values in render instead of via effect

--- a/apps/www/src/app/(auth)/sign-in/sign-up-form.tsx
+++ b/apps/www/src/app/(auth)/sign-in/sign-up-form.tsx
@@ -2,7 +2,7 @@
 
 import { signUp } from "@/actions/auth"
 import { Button } from "@components/ui/button"
-import { useForm } from "react-hook-form"
+import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { signUpFormSchema, type TSignUpFormSchema } from "@/lib/types/auth/sign-up-form-schema"
 import { useToast } from "cadence-core"
@@ -16,7 +16,6 @@ import {
   HelperText
 } from "cadence-core"
 import { useRouter } from "next/navigation"
-import { useState, useEffect } from "react"
 
 const checkPasswordRequirements = (password: string) => {
   if (!password) return false
@@ -33,23 +32,18 @@ const checkPasswordRequirements = (password: string) => {
 export const SignUpForm = () => {
   const { toast } = useToast()
   const router = useRouter()
-  const [passwordMeetsRequirements, setPasswordMeetsRequirements] = useState(false)
-  
   const {
     register,
     handleSubmit,
-    watch,
+    control,
     reset,
     formState: { errors, isSubmitting }
   } = useForm<TSignUpFormSchema>({
     resolver: zodResolver(signUpFormSchema)
   })
 
-  // Watch password field to check requirements
-  const password = watch("password")
-  useEffect(() => {
-    setPasswordMeetsRequirements(checkPasswordRequirements(password || ''))
-  }, [password])
+  const password = useWatch({ control, name: "password" })
+  const passwordMeetsRequirements = checkPasswordRequirements(password || '')
 
   const onSubmit = async (data: TSignUpFormSchema) => {
     try {

--- a/apps/www/src/app/(pages)/(educational-content)/articles/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/(educational-content)/articles/[slug]/page.tsx
@@ -50,107 +50,93 @@ export async function generateMetadata(
 
 // Generate static params
 export async function generateStaticParams() {
-	try {
-		const slugs = await sanityClient.fetch(
-			articlePaths,
-			{},
-			{ next: { revalidate: 60 } }
-		)
-		return slugs.map((slug: string) => ({ slug }))
-	} catch (error) {
-		console.error(error)
-		throw error
-	}
+	const slugs = await sanityClient.fetch(articlePaths, {}, { next: { revalidate: 60 } })
+	return slugs.map((slug: string) => ({ slug }))
 }
 
 // Render the article data
 export default async function ArticleSlugRoute({ params }: PageProps) {
 	const { slug } = await params
 
-	try {
-		const article = await sanityClient.fetch<ArticleData>(
-			articlesBySlugQuery,
-			{ slug },
-			{ next: { revalidate: 60 } }
-		)
+	const article = await sanityClient.fetch<ArticleData>(
+		articlesBySlugQuery,
+		{ slug },
+		{ next: { revalidate: 60 } }
+	)
 
-		if (!article) notFound()
+	if (!article) notFound()
 
-		const renderCategories = (
-			<Text tag="p" type="productive-body" size="body-small" collapse>
-				{article.categories.map((category, i) => (
-					<Fragment key={category.title}>
-						{i > 0 && ', '}
-						<Link href={linkResolver(category.slug, 'category')} type="secondary">
-							{category.title}
-						</Link>
-					</Fragment>
-				))}
-			</Text>
-		)
+	const renderCategories = (
+		<Text tag="p" type="productive-body" size="body-small" collapse>
+			{article.categories.map((category, i) => (
+				<Fragment key={category.title}>
+					{i > 0 && ', '}
+					<Link href={linkResolver(category.slug, 'category')} type="secondary">
+						{category.title}
+					</Link>
+				</Fragment>
+			))}
+		</Text>
+	)
 
-		return (
-			<>
-				<SectionContainer>
-					<FeaturedItem.Root>
-						<FeaturedItem.Title>
-							<Text
-								tag="h1"
-								type="expressive-headline"
-								size="h1"
-								color="high-contrast"
-								collapse
-							>
-								{article.title}
-							</Text>
-							<Text
-								tag="p"
-								type="expressive-body"
-								size="body-large"
-								color="high-contrast"
-								collapse
-							>
-								{article.excerpt}
-							</Text>
-						</FeaturedItem.Title>
-						<FeaturedItem.Image
-							image={getSanityImageUrl(article.featuredImage.image.asset).url()}
-							alt={article.featuredImage.alternativeText}
-						/>
-						<FeaturedItem.Description>
-							<AuthorMetadata
-								authors={article.authors}
-								date={prettyDate(article.date)}
-							>
-								{renderCategories}
-							</AuthorMetadata>
-							<ReadingLength
-								content={article.content.content}
-								preContent="Around a "
-							/>
-							{article.changelog && article.changelog.length > 0 && (
-								<ChangelogDrawer changelog={article.changelog} />
-							)}
-						</FeaturedItem.Description>
-					</FeaturedItem.Root>
-				</SectionContainer>
-				<Flex tag="div" direction="row" gap="2x-large" className={s.content}>
-					<RichTextWrapper>
-						<RichText value={article.content.content} />
-						<NewsletterSignup
-							title="Enjoy this article?"
-							description="Get new and interesting articles directly in your inbox. Generally every few weeks or once a month."
-						/>
-					</RichTextWrapper>
-					<TableOfContents
-						content={article.content.content}
-						title="On this page"
+	return (
+		<>
+			<SectionContainer>
+				<FeaturedItem.Root>
+					<FeaturedItem.Title>
+						<Text
+							tag="h1"
+							type="expressive-headline"
+							size="h1"
+							color="high-contrast"
+							collapse
+						>
+							{article.title}
+						</Text>
+						<Text
+							tag="p"
+							type="expressive-body"
+							size="body-large"
+							color="high-contrast"
+							collapse
+						>
+							{article.excerpt}
+						</Text>
+					</FeaturedItem.Title>
+					<FeaturedItem.Image
+						image={getSanityImageUrl(article.featuredImage.image.asset).url()}
+						alt={article.featuredImage.alternativeText}
 					/>
-				</Flex>
-			</>
-		)
-	} catch (error) {
-		console.error(error)
-		throw error
-	}
+					<FeaturedItem.Description>
+						<AuthorMetadata
+							authors={article.authors}
+							date={prettyDate(article.date)}
+						>
+							{renderCategories}
+						</AuthorMetadata>
+						<ReadingLength
+							content={article.content.content}
+							preContent="Around a "
+						/>
+						{article.changelog && article.changelog.length > 0 && (
+							<ChangelogDrawer changelog={article.changelog} />
+						)}
+					</FeaturedItem.Description>
+				</FeaturedItem.Root>
+			</SectionContainer>
+			<Flex tag="div" direction="row" gap="2x-large" className={s.content}>
+				<RichTextWrapper>
+					<RichText value={article.content.content} />
+					<NewsletterSignup
+						title="Enjoy this article?"
+						description="Get new and interesting articles directly in your inbox. Generally every few weeks or once a month."
+					/>
+				</RichTextWrapper>
+				<TableOfContents
+					content={article.content.content}
+					title="On this page"
+				/>
+			</Flex>
+		</>
+	)
 }

--- a/apps/www/src/app/(pages)/(educational-content)/categories/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/(educational-content)/categories/[slug]/page.tsx
@@ -43,63 +43,23 @@ export async function generateMetadata(
 
 // Generate slugs/routes for categories
 export async function generateStaticParams(): Promise<CategoryParams[]> {
-	try {
-		const slugs: CategorySlug[] = await client.fetch(categoryPaths,
-			{},
-			{
-				next: {
-					revalidate: 60,
-				}
-			}
-		)
-		return slugs.map((slug: string) => ({ slug }))
-	} catch (error) {
-		console.error(error)
-		throw error
-	}
+	const slugs: CategorySlug[] = await client.fetch(categoryPaths, {}, { next: { revalidate: 60 } })
+	return slugs.map((slug: string) => ({ slug }))
 }
 
 // Render the category data
 export default async function CategorySlugRoute({ params }: { params: Promise<{ slug: string }> }) {
 	const { slug } = await params
 
-	try {
-		const category = await client.fetch(
-			categoriesBySlugQuery,
-			{ slug },
-			{
-				next: {
-					revalidate: 60,
-				},
-			}
-		)
+	const category = await client.fetch(
+		categoriesBySlugQuery,
+		{ slug },
+		{ next: { revalidate: 60 } }
+	)
 
-		if (!category) notFound()
+	if (!category) notFound()
 
-		if (!category.references || category.references.length === 0) {
-			return (
-				<SectionContainer>
-					<SectionTitle
-						background="success"
-						title={
-							<Text
-								tag="h1"
-								type="expressive-headline"
-								size="h1"
-								collapse
-								color="high-contrast"
-							>
-								Category: {category.title}
-							</Text>
-						}
-					/>
-					<Text type="expressive-body" size="body-base" color="primary">
-						No references found in this category.
-					</Text>
-				</SectionContainer>
-			)
-		}
-
+	if (!category.references || category.references.length === 0) {
 		return (
 			<SectionContainer>
 				<SectionTitle
@@ -116,26 +76,44 @@ export default async function CategorySlugRoute({ params }: { params: Promise<{ 
 						</Text>
 					}
 				/>
-				{category.references.map((reference: CategoryReference) => {
-					// Handle potentially complex reference data
-					const title = typeof reference.title === 'string' ? reference.title : 'Untitled'
-					const description = typeof reference.excerpt === 'string' ? reference.excerpt : ''
-					const refType = reference._type || 'article'
-					const refSlug = typeof reference.slug === 'string' ? reference.slug : ''
-					
-					return (
-						<ListItem
-							key={reference._id}
-							title={title}
-							description={description}
-							url={linkResolver(refSlug, refType)}
-						/>
-					)
-				})}
+				<Text type="expressive-body" size="body-base" color="primary">
+					No references found in this category.
+				</Text>
 			</SectionContainer>
 		)
-	} catch (error) {
-		console.error('Error rendering category:', error)
-		throw error
 	}
+
+	return (
+		<SectionContainer>
+			<SectionTitle
+				background="success"
+				title={
+					<Text
+						tag="h1"
+						type="expressive-headline"
+						size="h1"
+						collapse
+						color="high-contrast"
+					>
+						Category: {category.title}
+					</Text>
+				}
+			/>
+			{category.references.map((reference: CategoryReference) => {
+				const title = typeof reference.title === 'string' ? reference.title : 'Untitled'
+				const description = typeof reference.excerpt === 'string' ? reference.excerpt : ''
+				const refType = reference._type || 'article'
+				const refSlug = typeof reference.slug === 'string' ? reference.slug : ''
+
+				return (
+					<ListItem
+						key={reference._id}
+						title={title}
+						description={description}
+						url={linkResolver(refSlug, refType)}
+					/>
+				)
+			})}
+		</SectionContainer>
+	)
 }

--- a/apps/www/src/app/(pages)/(marketing)/links/page.tsx
+++ b/apps/www/src/app/(pages)/(marketing)/links/page.tsx
@@ -20,53 +20,39 @@ export const metadata: Metadata = {
 
 // Render the page data
 export default async function LinkInBioPage() {
-	try {
-		const links = await client.fetch(
-			linkInBioPageQuery,
-			{},
-			{
-				next: {
-					revalidate: 60,
-				},
-			}
-		)
-		if (!links) {
-			return notFound()
-		}
+	const links = await client.fetch(linkInBioPageQuery, {}, { next: { revalidate: 60 } })
 
-		const renderLinks = links.map((link: { _id: string; title: string; description: string; link: { slug: string; _type: string }; date: string }) => {
-			return (
-				<ListItem
-					key={link._id}
-					title={link.title}
-					description={link.description}
-					url={linkResolver(link.link.slug, link.link._type)}
-					date={prettyDate(link.date)}
-				/>
-			)
-		})
-
-		return (
-			<SectionContainer>
-				<SectionTitle
-					background="primary"
-					title={
-						<Text
-							type="expressive-headline"
-							size="h4"
-							tag="h1"
-							color="brand"
-							collapse
-						>
-							Downbeat Academy Links
-						</Text>
-					}
-				/>
-				{renderLinks}
-			</SectionContainer>
-		)
-	} catch (error) {
-		console.error(error)
-		throw error
+	if (!links) {
+		return notFound()
 	}
+
+	const renderLinks = links.map((link: { _id: string; title: string; description: string; link: { slug: string; _type: string }; date: string }) => (
+		<ListItem
+			key={link._id}
+			title={link.title}
+			description={link.description}
+			url={linkResolver(link.link.slug, link.link._type)}
+			date={prettyDate(link.date)}
+		/>
+	))
+
+	return (
+		<SectionContainer>
+			<SectionTitle
+				background="primary"
+				title={
+					<Text
+						type="expressive-headline"
+						size="h4"
+						tag="h1"
+						color="brand"
+						collapse
+					>
+						Downbeat Academy Links
+					</Text>
+				}
+			/>
+			{renderLinks}
+		</SectionContainer>
+	)
 }

--- a/apps/www/src/app/(pages)/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/[slug]/page.tsx
@@ -56,13 +56,8 @@ export async function generateMetadata(
 
 // Generate the slugs/routes for each page
 export async function generateStaticParams(): Promise<SlugParams[]> {
-	try {
-		const slugs: SlugString[] = await client.fetch(pagePaths)
-		return slugs.map((slug: string) => ({ slug }))
-	} catch (error) {
-		console.error(error)
-		throw error
-	}
+	const slugs: SlugString[] = await client.fetch(pagePaths)
+	return slugs.map((slug: string) => ({ slug }))
 }
 
 // Render the page data
@@ -70,37 +65,31 @@ export default async function PageSlugRoute({ params }: { params: Promise<{ slug
 	const { slug } = await params
 	const preview = (await draftMode()).isEnabled ? { token: readToken } : undefined
 
-	try {
-		const page = await sanityClient.fetch(pagesBySlugQuery, {
-			slug,
-		})
+	const page = await sanityClient.fetch(pagesBySlugQuery, { slug })
 
-		if (!page && !preview) {
-			notFound()
-		}
-		return (
-			<>
-				<SectionContainer>
-					<SectionTitle
-						background="primary"
-						title={
-							<Text
-								tag="h1"
-								size="h1"
-								type="expressive-headline"
-								color="brand"
-								collapse
-							>
-								{page.title}
-							</Text>
-						}
-					/>
-					<ModuleRenderer modules={page.moduleContent} />
-				</SectionContainer>
-			</>
-		)
-	} catch (error) {
-		console.error(error)
-		throw error
+	if (!page && !preview) {
+		notFound()
 	}
+
+	return (
+		<>
+			<SectionContainer>
+				<SectionTitle
+					background="primary"
+					title={
+						<Text
+							tag="h1"
+							size="h1"
+							type="expressive-headline"
+							color="brand"
+							collapse
+						>
+							{page.title}
+						</Text>
+					}
+				/>
+				<ModuleRenderer modules={page.moduleContent} />
+			</SectionContainer>
+		</>
+	)
 }

--- a/apps/www/src/app/(pages)/contributors/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/contributors/[slug]/page.tsx
@@ -43,21 +43,12 @@ export async function generateMetadata(
 
 // Generate the routes for each page
 export async function generateStaticParams(): Promise<SlugParams[]> {
-	try {
-		const slugs: SlugString[] = await client.fetch(
-			contributorPaths,
-			{},
-			{
-				next: {
-					revalidate: 60,
-				}
-			}
-		)
-		return slugs.map((slug: string) => ({ slug }))
-	} catch (error) {
-		console.error(error)
-		throw error
-	}
+	const slugs: SlugString[] = await client.fetch(
+		contributorPaths,
+		{},
+		{ next: { revalidate: 60 } }
+	)
+	return slugs.map((slug: string) => ({ slug }))
 }
 
 // Render the page data
@@ -65,76 +56,65 @@ export default async function ContributorSlugRoute({ params }: { params: Promise
 	const { slug } = await params
 	const preview = (await draftMode()).isEnabled ? { token: readToken } : undefined
 
-	try {
-		const contributor = await sanityClient.fetch(
-			contributorsBySlugQuery,
-			{ slug },
-			{
-				next: {
-					revalidate: 60,
-				}
-			}
-		)
+	const contributor = await sanityClient.fetch(
+		contributorsBySlugQuery,
+		{ slug },
+		{ next: { revalidate: 60 } }
+	)
 
-		if (!contributor && !preview) {
-			notFound()
-		}
-
-		return (
-			<>
-				<SectionContainer>
-					<FeaturedItem.Root>
-						<FeaturedItem.Title>
-							<Text
-								tag="h1"
-								size="h1"
-								type="expressive-headline"
-								color="high-contrast"
-								collapse
-							>
-								{contributor.name}
-							</Text>
-						</FeaturedItem.Title>
-						<FeaturedItem.Description>
-							<RichText value={contributor.biography.content} />
-						</FeaturedItem.Description>
-						<FeaturedItem.Image
-							image={getSanityImageUrl(contributor.image.image.asset).url()}
-							alt={contributor.name}
-						/>
-					</FeaturedItem.Root>
-				</SectionContainer>
-				<SectionContainer>
-					<SectionTitle
-						title={
-							<Text
-								tag="h2"
-								type="expressive-headline"
-								size="h2"
-								color="primary"
-								collapse
-							>
-								Contributions
-							</Text>
-						}
-					/>
-					<Flex direction="column" tag="section">
-						{contributor.content.map((c: { _id: string; title: string; excerpt: string; slug: string; type: string }) => {
-							return (
-								<ListItem
-									key={c._id}
-									title={c.title}
-									description={c.excerpt}
-									url={linkResolver(c.slug, c.type)}
-								/>
-							)
-						})}
-					</Flex>
-				</SectionContainer>
-			</>
-		)
-	} catch (error) {
-		console.error(error)
-		throw error
+	if (!contributor && !preview) {
+		notFound()
 	}
+
+	return (
+		<>
+			<SectionContainer>
+				<FeaturedItem.Root>
+					<FeaturedItem.Title>
+						<Text
+							tag="h1"
+							size="h1"
+							type="expressive-headline"
+							color="high-contrast"
+							collapse
+						>
+							{contributor.name}
+						</Text>
+					</FeaturedItem.Title>
+					<FeaturedItem.Description>
+						<RichText value={contributor.biography.content} />
+					</FeaturedItem.Description>
+					<FeaturedItem.Image
+						image={getSanityImageUrl(contributor.image.image.asset).url()}
+						alt={contributor.name}
+					/>
+				</FeaturedItem.Root>
+			</SectionContainer>
+			<SectionContainer>
+				<SectionTitle
+					title={
+						<Text
+							tag="h2"
+							type="expressive-headline"
+							size="h2"
+							color="primary"
+							collapse
+						>
+							Contributions
+						</Text>
+					}
+				/>
+				<Flex direction="column" tag="section">
+					{contributor.content.map((c: { _id: string; title: string; excerpt: string; slug: string; type: string }) => (
+						<ListItem
+							key={c._id}
+							title={c.title}
+							description={c.excerpt}
+							url={linkResolver(c.slug, c.type)}
+						/>
+					))}
+				</Flex>
+			</SectionContainer>
+		</>
+	)
 }

--- a/apps/www/src/components/music-notation/music-notation/open-sheet-music-display.tsx
+++ b/apps/www/src/components/music-notation/music-notation/open-sheet-music-display.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic'
 import { OpenSheetMusicDisplayProps } from './types'
 import { Text, SkeletonLoader } from 'cadence-core'
 import 'react-loading-skeleton/dist/skeleton.css'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useSyncExternalStore } from 'react'
 
 const OSMDComponent = dynamic(
   () => import('./osmd-component'),
@@ -14,20 +14,22 @@ const OSMDComponent = dynamic(
 )
 
 export const OpenSheetMusicDisplay = (props: OpenSheetMusicDisplayProps) => {
-  const [hasMounted, setHasMounted] = useState(false)
+  // Detects client-side mount without state-in-effect: false on server, true on client
+  const hasMounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  )
   const [isLoading, setIsLoading] = useState(true)
   const [isVisible, setIsVisible] = useState(false)
-  const [key, setKey] = useState(0) // Add key for forcing remount
+  const [prevFile, setPrevFile] = useState(props.file)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    setHasMounted(true)
-  }, [])
-
-  useEffect(() => {
+  // Reset loading state when file changes (during render, not in an effect)
+  if (prevFile !== props.file) {
+    setPrevFile(props.file)
     setIsLoading(true)
-    setKey(prev => prev + 1) // Force remount when file changes
-  }, [props.file])
+  }
 
   // Only load OSMD when the component is near the viewport
   useEffect(() => {
@@ -58,7 +60,7 @@ export const OpenSheetMusicDisplay = (props: OpenSheetMusicDisplayProps) => {
       {isVisible && (
         <div style={{ display: isLoading ? 'none' : 'block' }}>
           <OSMDComponent
-            key={key}
+            key={props.file}
             {...props}
             onRenderComplete={() => setIsLoading(false)}
           />

--- a/apps/www/src/components/navigation/main/header-navigation.tsx
+++ b/apps/www/src/components/navigation/main/header-navigation.tsx
@@ -81,7 +81,7 @@ const HeaderNavigation = ({ className, initialSession }: HeaderNavigationProps) 
 			// then redirect back to the home page
 			const authServiceUrl = process.env.NEXT_PUBLIC_AUTH_SERVICE_URL || 'http://localhost:3002'
 			const appUrl = process.env.NEXT_PUBLIC_PROJECT_URL || 'http://localhost:3000'
-			window.location.href = `${authServiceUrl}/sign-out?redirect_uri=${encodeURIComponent(appUrl)}`
+			window.location.assign(`${authServiceUrl}/sign-out?redirect_uri=${encodeURIComponent(appUrl)}`)
 		} catch (error) {
 			// Fallback to server action
 			await signOut()

--- a/apps/www/src/components/navigation/main/nav-content.tsx
+++ b/apps/www/src/components/navigation/main/nav-content.tsx
@@ -63,7 +63,11 @@ const NavContent = ({ links, isAuthenticated, signInHref, onSignOut }: NavConten
 		}
 	}, [navToggled])
 
-	useEffect(() => setNavToggled(false), [route])
+	const [prevRoute, setPrevRoute] = useState(route)
+	if (prevRoute !== route) {
+		setPrevRoute(route)
+		setNavToggled(false)
+	}
 
 	const staticLinks = [
 		{

--- a/apps/www/src/components/table-of-contents/table-of-contents.tsx
+++ b/apps/www/src/components/table-of-contents/table-of-contents.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo, useSyncExternalStore } from 'react'
 import classnames from 'classnames'
 import { Text } from 'cadence-core'
 import { Link } from '@components/link'
@@ -19,61 +19,59 @@ interface TableOfContentsProps {
 	className?: string
 }
 
+function subscribeToWindowResize(callback: () => void) {
+	window.addEventListener('resize', callback)
+	return () => window.removeEventListener('resize', callback)
+}
+
 const TableOfContents = ({
 	content,
 	title,
 	className,
 }: TableOfContentsProps) => {
-	const [headings, setHeadings] = useState<Heading[]>([])
 	const [activeId, setActiveId] = useState<string>('')
-	const [isExpanded, setIsExpanded] = useState(true)
-	const [hasMounted, setHasMounted] = useState(false)
+	const [manualExpanded, setManualExpanded] = useState<boolean | null>(null)
 
-	// Set initial expanded state based on viewport width
-	useEffect(() => {
-		setHasMounted(true)
-		setIsExpanded(window.innerWidth > 1200)
+	// Detects client-side mount without state-in-effect: false on server, true on client
+	const hasMounted = useSyncExternalStore(
+		() => () => {},
+		() => true,
+		() => false,
+	)
 
-		const handleResize = () => {
-			setIsExpanded(window.innerWidth > 1200)
-		}
+	// Viewport-based expansion — auto-syncs with window.innerWidth via subscription
+	const isWideViewport = useSyncExternalStore(
+		subscribeToWindowResize,
+		() => window.innerWidth > 1200,
+		() => true,
+	)
 
-		window.addEventListener('resize', handleResize)
-		return () => window.removeEventListener('resize', handleResize)
-	}, [])
+	const isExpanded = manualExpanded !== null ? manualExpanded : isWideViewport
+	// Use SSR-matching value (true) until after mount to avoid hydration mismatch
+	const effectiveExpanded = hasMounted ? isExpanded : true
 
-	// Extract headings from Portable Text content
-	useEffect(() => {
-		const extractTextFromChildren = (children: any[]): string => {
-			return children
+	// Headings are pure derivation from content — no state or effect needed
+	const headings = useMemo<Heading[]>(() => {
+		if (!content) return []
+
+		const extractTextFromChildren = (children: any[]): string =>
+			children
 				.map((child) => {
 					if (typeof child.text === 'string') return child.text
-					if (child.marks && child.marks.length > 0) {
-						// Handle formatted text (e.g., emphasis)
-						return child.text
-					}
 					return ''
 				})
 				.join('')
-		}
 
-		const extractHeadings = (blocks: any[]): Heading[] => {
-			return blocks
-				.filter((block) => block.style && block.style.startsWith('h'))
-				.map((block) => {
-					const text = extractTextFromChildren(block.children)
-					const id = slugify([text])
-					return {
-						id,
-						text,
-						level: parseInt(block.style.substring(1)),
-					}
-				})
-		}
-
-		if (content) {
-			setHeadings(extractHeadings(content))
-		}
+		return content
+			.filter((block: any) => block.style && block.style.startsWith('h'))
+			.map((block: any) => {
+				const text = extractTextFromChildren(block.children)
+				return {
+					id: slugify([text]),
+					text,
+					level: parseInt(block.style.substring(1)),
+				}
+			})
 	}, [content])
 
 	// Handle scroll spy
@@ -102,9 +100,6 @@ const TableOfContents = ({
 
 	if (headings.length === 0) return null
 
-	// Use SSR-matching value (true) until after mount to avoid hydration mismatch
-	const effectiveExpanded = hasMounted ? isExpanded : true
-
 	const classes = classnames(s.root, className, {
 		[s.collapsed]: !effectiveExpanded,
 		[s.expanded]: effectiveExpanded,
@@ -114,7 +109,7 @@ const TableOfContents = ({
 		<nav className={classes} aria-label="Table of contents">
 			<button
 				className={s.titleButton}
-				onClick={() => setIsExpanded(!isExpanded)}
+				onClick={() => setManualExpanded(!effectiveExpanded)}
 				aria-expanded={effectiveExpanded}
 			>
 				<Text
@@ -150,7 +145,7 @@ const TableOfContents = ({
 									})
 									// Close the bottom sheet after clicking a link on mobile
 									if (window.innerWidth <= 1200) {
-										setIsExpanded(false)
+										setManualExpanded(false)
 									}
 								}}
 							>


### PR DESCRIPTION
…ext 16.2

- react-hooks/error-boundaries (37): remove try/catch wrappers from server page components — JSX is now constructed outside try blocks; useless re-throw guards in generateStaticParams and page route functions are removed entirely

- react-hooks/set-state-in-effect (4): replace setState-in-effect patterns with derived state (useMemo, during-render state resets) and useSyncExternalStore for browser API subscriptions (window resize, mount detection)

- react-hooks/immutability (1): replace window.location.href assignment with window.location.assign() in header-navigation

- react-hooks/incompatible-library (1): replace react-hook-form watch() with useWatch() in sign-up-form; derive passwordMeetsRequirements in render

https://claude.ai/code/session_01CogohbmPQp1uNvmr2pKV1W