### PR TITLE
fix(www): prevent dynamic generateMetadata from throwing on missing content

### DIFF
--- a/.changeset/fix-dynamic-metadata-errors.md
+++ b/.changeset/fix-dynamic-metadata-errors.md
@@ -1,0 +1,7 @@
+---
+"www": patch
+---
+
+Prevent dynamic page `generateMetadata` from throwing on missing content.
+
+The articles, handbook, lexicon, categories, and contributors routes re-threw errors from their `catch` blocks and accessed Sanity fields without null checks, so a slug resolving to `null` (unpublished, deleted, draft-only, or stale ISR paths) surfaced as a thrown error in Sentry. These routes now null-check the fetched document (and nested metadata) and return empty metadata instead of throwing, mirroring the existing `[slug]` route. Also hardened the shared helpers: `getOgTitle` no longer emits `"undefined ♪ Downbeat Academy"` for missing titles, and `limitDescription` now correctly returns a truncated value.

--- a/apps/www/src/app/(pages)/(educational-content)/articles/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/(educational-content)/articles/[slug]/page.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata(
 			{ next: { revalidate: 60 } }
 		)
 
-		if (!article) return {}
+		if (!article || !article.metadata) return {}
 
 		return {
 			title: getOgTitle(article.metadata.title),
@@ -44,7 +44,7 @@ export async function generateMetadata(
 		}
 	} catch (error) {
 		console.error(error)
-		throw error
+		return {}
 	}
 }
 

--- a/apps/www/src/app/(pages)/(educational-content)/categories/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/(educational-content)/categories/[slug]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata(
 		}
 	} catch (error) {
 		console.error(error)
-		throw error
+		return {}
 	}
 }
 

--- a/apps/www/src/app/(pages)/(educational-content)/handbook/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/(educational-content)/handbook/[slug]/page.tsx
@@ -32,13 +32,15 @@ export async function generateMetadata(
 			}
 		)
 
+		if (!article) return {}
+
 		return {
 			title: getOgTitle(article.title),
 			description: article.excerpt,
 		}
 	} catch (error) {
 		console.error(error)
-		throw error
+		return {}
 	}
 }
 

--- a/apps/www/src/app/(pages)/(educational-content)/lexicon/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/(educational-content)/lexicon/[slug]/page.tsx
@@ -32,16 +32,21 @@ export async function generateMetadata({
 			}
 		)
 
+		if (!lexicon) return {}
+
+		const titleParts = [lexicon.artist, lexicon.album, lexicon.track]
+		if (lexicon.timestamp) {
+			titleParts.push(formatTime(lexicon.timestamp).totalTime)
+		}
+		const lexiconTitle = titleParts.filter(Boolean).join(' - ')
+
 		return {
-			title: getOgTitle(
-				`${lexicon.artist} - ${lexicon.album} - ${lexicon.track} - ${formatTime(lexicon.timestamp).totalTime
-				}`
-			),
+			title: getOgTitle(lexiconTitle || 'Lexicon'),
 			description: lexicon.excerpt,
 		}
 	} catch (error) {
 		console.error(error)
-		throw error
+		return {}
 	}
 }
 

--- a/apps/www/src/app/(pages)/contributors/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/contributors/[slug]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata(
 		}
 	} catch (error) {
 		console.error(error)
-		throw error
+		return {}
 	}
 }
 

--- a/apps/www/src/utils/metaHelpers.ts
+++ b/apps/www/src/utils/metaHelpers.ts
@@ -1,9 +1,12 @@
-const getOgTitle = (title) => {
+const getOgTitle = (title?: string) => {
+	if (!title) return 'Downbeat Academy'
 	return title + ' ♪ Downbeat Academy'
 }
 
-const limitDescription = (description) => {
-	description > 200 ? description.substring(0, 200) : description
+const limitDescription = (description?: string) => {
+	return description && description.length > 200
+		? description.substring(0, 200)
+		: description
 }
 
 export { getOgTitle, limitDescription }


### PR DESCRIPTION
Dynamic metadata routes re-threw errors in their catch blocks and accessed
Sanity fields without null checks. When a slug resolved to null (unpublished,
deleted, draft-only, or stale ISR paths) or a nested field was missing, the
resulting TypeError was re-thrown, failing the route render and surfacing in
Sentry.

Mirror the already-fixed (pages)/[slug] route across articles, handbook,
lexicon, categories, and contributors: null-check the fetched document (and
nested metadata) and return {} on missing data; in catch, log and return {}
instead of re-throwing so generateMetadata never throws.

Also harden shared helpers: getOgTitle no longer emits "undefined ♪ ..." for
missing titles, and limitDescription now actually returns a (correctly
truncated) value.