### PR TITLE
Add Vitest unit/integration test layer for www app

### DIFF
--- a/.changeset/www-vitest-unit-tests.md
+++ b/.changeset/www-vitest-unit-tests.md
@@ -1,0 +1,15 @@
+---
+"www": patch
+---
+
+Add a Vitest unit/integration test layer for `apps/www` covering pure utilities,
+Zod form schemas, the reading-length calculator, the music-notation transformers,
+and the server actions (auth, email, profile). Fix bugs surfaced by the new tests:
+
+- `limitDescription()` now returns its result and compares string length (it
+  previously returned `undefined` for every input).
+- `transformAccidental()` handles the `"sharp"` accidental (was a `"share"`
+  typo) and returns `null` for unsupported input instead of `undefined`.
+- `linkResolver()` drops a duplicate, unreachable `category` case.
+- The update-password schema maps its "passwords do not match" error to the
+  real `confirmNewPassword` field.

--- a/.github/workflows/ci-www.yml
+++ b/.github/workflows/ci-www.yml
@@ -35,6 +35,35 @@ jobs:
         run: pnpm run lint
         working-directory: apps/www
 
+  unit-tests:
+    name: 'Unit Tests'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+      - name: Install Dependencies
+        run: pnpm install
+        env:
+          # Unit tests are fully mocked and never launch a browser, so skip the
+          # Cypress binary download to keep this job fast and self-contained.
+          CYPRESS_INSTALL_BINARY: '0'
+      - name: Run unit tests with coverage
+        run: pnpm --filter www test:coverage
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: www-unit-coverage
+          path: apps/www/coverage
+
   # E2E tests moved to separate workflow for better control
   # See .github/workflows/ci-www-e2e.yml
   e2e-tests:

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -34,6 +34,9 @@
 		"cypress:run:a11y": "cypress run --spec 'cypress/e2e/accessibility/**'",
 		"cypress:run:a11y:only": "CYPRESS_SKIP_OVERRIDE=true cypress run --spec 'cypress/e2e/accessibility/**'",
 		"cypress:run:journeys": "cypress run --spec 'cypress/e2e/journeys/**'",
+		"test": "vitest",
+		"test:run": "vitest run",
+		"test:coverage": "vitest run --coverage",
 		"test:e2e": "start-server-and-test dev http://localhost:3000 cypress:run",
 		"test:e2e:ci": "start-server-and-test start http://localhost:3000 cypress:run:ci",
 		"analyze": "ANALYZE=true pnpm build",
@@ -110,19 +113,28 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
+		"@testing-library/jest-dom": "^6.6.3",
+		"@testing-library/react": "^16.3.2",
+		"@testing-library/user-event": "^14.6.1",
 		"@types/node": "^25.6.2",
 		"@types/pg": "^8.20.0",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.1.6",
+		"@vitejs/plugin-react": "^6.0.1",
+		"@vitest/coverage-v8": "^4.1.6",
 		"bcryptjs": "^3.0.3",
 		"cypress": "^15.14.2",
 		"cypress-axe": "^1.7.0",
 		"drizzle-kit": "^0.31.10",
 		"ignore-loader": "^0.1.2",
+		"jsdom": "^26.1.0",
 		"nanoid": "^5.1.11",
 		"postgres": "^3.4.9",
 		"start-server-and-test": "^2.1.5",
 		"tsx": "^4.21.0",
-		"typescript": "^5.9.3"
+		"typescript": "^5.9.3",
+		"vite": "^8.0.12",
+		"vite-tsconfig-paths": "^6.1.1",
+		"vitest": "^4.1.6"
 	}
 }

--- a/apps/www/setup-tests.ts
+++ b/apps/www/setup-tests.ts
@@ -1,0 +1,42 @@
+/// <reference types="vitest" />
+
+import '@testing-library/jest-dom/vitest'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+// Unmount any rendered components and reset jsdom between tests.
+afterEach(() => {
+	cleanup()
+})
+
+// Mock ResizeObserver for tests (mirrors cadence-core setup; needed by Radix UI).
+global.ResizeObserver =
+	global.ResizeObserver ||
+	class ResizeObserver {
+		constructor(_callback: ResizeObserverCallback) {}
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	}
+
+// Mock scrollIntoView for Radix UI Select tests.
+Element.prototype.scrollIntoView =
+	Element.prototype.scrollIntoView || function () {}
+
+// Mock pointer capture APIs for Radix UI components.
+Element.prototype.hasPointerCapture =
+	Element.prototype.hasPointerCapture ||
+	function () {
+		return false
+	}
+Element.prototype.setPointerCapture =
+	Element.prototype.setPointerCapture || function () {}
+Element.prototype.releasePointerCapture =
+	Element.prototype.releasePointerCapture || function () {}
+
+// Provide placeholder env vars consumed at import time by Sanity/Resend modules
+// so importing the units under test never throws during collection.
+process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ||= 'test-project'
+process.env.NEXT_PUBLIC_SANITY_DATASET ||= 'test-dataset'
+process.env.NEXT_PUBLIC_SANITY_API_VERSION ||= '2024-01-01'
+process.env.RESEND_API_KEY ||= 'test-resend-key'

--- a/apps/www/src/actions/auth/__test__/forgot-password.test.ts
+++ b/apps/www/src/actions/auth/__test__/forgot-password.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { requestPasswordReset } = vi.hoisted(() => ({
+	requestPasswordReset: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/auth', () => ({
+	auth: { api: { requestPasswordReset } },
+}))
+
+import { forgotPasswordAction } from '../forgot-password'
+
+describe('forgotPasswordAction', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+	})
+
+	it('requests a password reset and returns success', async () => {
+		const result = await forgotPasswordAction('user@example.com')
+		expect(requestPasswordReset).toHaveBeenCalledWith({
+			body: {
+				email: 'user@example.com',
+				redirectTo: '/account/update-password',
+			},
+		})
+		expect(result).toEqual({ success: true })
+	})
+
+	it('returns a not-found message when the user does not exist', async () => {
+		requestPasswordReset.mockRejectedValueOnce(new Error('User not found'))
+		const result = await forgotPasswordAction('missing@example.com')
+		expect(result).toEqual({
+			error: 'No account found with this email address',
+		})
+	})
+
+	it('returns a generic error for other failures', async () => {
+		requestPasswordReset.mockRejectedValueOnce(new Error('smtp down'))
+		const result = await forgotPasswordAction('user@example.com')
+		expect(result).toEqual({
+			error: 'Failed to send password reset email. Please try again.',
+		})
+	})
+})

--- a/apps/www/src/actions/auth/__test__/reset-password.test.ts
+++ b/apps/www/src/actions/auth/__test__/reset-password.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { resetPassword } = vi.hoisted(() => ({ resetPassword: vi.fn() }))
+
+vi.mock('@/lib/auth/auth', () => ({ auth: { api: { resetPassword } } }))
+
+import { resetPasswordAction } from '../reset-password'
+
+describe('resetPasswordAction', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+	})
+
+	it('resets the password and returns success', async () => {
+		const result = await resetPasswordAction({
+			newPassword: 'NewPass1!',
+			token: 'tok_123',
+		})
+		expect(resetPassword).toHaveBeenCalledWith({
+			body: { newPassword: 'NewPass1!', token: 'tok_123' },
+		})
+		expect(result).toEqual({ success: true })
+	})
+
+	it('returns the error message when the reset fails', async () => {
+		resetPassword.mockRejectedValueOnce(new Error('Token expired'))
+		const result = await resetPasswordAction({
+			newPassword: 'NewPass1!',
+			token: 'tok_123',
+		})
+		expect(result).toEqual({ error: 'Token expired' })
+	})
+
+	it('falls back to a generic error when none is provided', async () => {
+		resetPassword.mockRejectedValueOnce({})
+		const result = await resetPasswordAction({
+			newPassword: 'NewPass1!',
+			token: 'tok_123',
+		})
+		expect(result).toEqual({
+			error: 'Failed to reset password. Please try again.',
+		})
+	})
+})

--- a/apps/www/src/actions/auth/__test__/sign-in.test.ts
+++ b/apps/www/src/actions/auth/__test__/sign-in.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { signInEmail, redirect, headers } = vi.hoisted(() => ({
+	signInEmail: vi.fn(),
+	redirect: vi.fn(() => {
+		// next/navigation's redirect signals control flow by throwing.
+		throw new Error('NEXT_REDIRECT')
+	}),
+	headers: vi.fn(async () => new Headers()),
+}))
+
+vi.mock('@/lib/auth/auth', () => ({ auth: { api: { signInEmail } } }))
+vi.mock('next/headers', () => ({ headers }))
+vi.mock('next/navigation', () => ({ redirect }))
+
+import { signIn } from '../sign-in'
+
+const formDataFor = (fields: Record<string, string>) => {
+	const fd = new FormData()
+	for (const [key, value] of Object.entries(fields)) fd.append(key, value)
+	return fd
+}
+
+const validForm = () =>
+	formDataFor({ email: 'a@b.com', password: 'secret123' })
+
+describe('signIn', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+	})
+
+	it('throws when fields are missing', async () => {
+		await expect(signIn(formDataFor({ email: 'a@b.com' }))).rejects.toThrow(
+			'Email and password are required'
+		)
+	})
+
+	it('redirects to /account after a successful sign in', async () => {
+		await expect(signIn(validForm())).rejects.toThrow('NEXT_REDIRECT')
+		expect(signInEmail).toHaveBeenCalledOnce()
+		expect(redirect).toHaveBeenCalledWith('/account')
+	})
+
+	it('maps INVALID_CREDENTIALS', async () => {
+		signInEmail.mockRejectedValueOnce({ body: { code: 'INVALID_CREDENTIALS' } })
+		await expect(signIn(validForm())).rejects.toThrow('Invalid email or password')
+		expect(redirect).not.toHaveBeenCalled()
+	})
+
+	it('maps USER_NOT_FOUND', async () => {
+		signInEmail.mockRejectedValueOnce({ body: { code: 'USER_NOT_FOUND' } })
+		await expect(signIn(validForm())).rejects.toThrow(
+			'This email is not registered. Please create an account first.'
+		)
+	})
+
+	it('maps EMAIL_NOT_VERIFIED', async () => {
+		signInEmail.mockRejectedValueOnce({ body: { code: 'EMAIL_NOT_VERIFIED' } })
+		await expect(signIn(validForm())).rejects.toThrow(
+			'Please verify your email address.'
+		)
+	})
+
+	it('rethrows unknown errors', async () => {
+		signInEmail.mockRejectedValueOnce(new Error('network down'))
+		await expect(signIn(validForm())).rejects.toThrow('network down')
+	})
+})

--- a/apps/www/src/actions/auth/__test__/sign-out.test.ts
+++ b/apps/www/src/actions/auth/__test__/sign-out.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { signOut: signOutApi, redirect, revalidatePath, headers } = vi.hoisted(
+	() => ({
+		signOut: vi.fn(),
+		redirect: vi.fn(() => {
+			throw new Error('NEXT_REDIRECT')
+		}),
+		revalidatePath: vi.fn(),
+		headers: vi.fn(async () => new Headers()),
+	})
+)
+
+vi.mock('@/lib/auth/auth', () => ({ auth: { api: { signOut: signOutApi } } }))
+vi.mock('next/navigation', () => ({ redirect }))
+vi.mock('next/cache', () => ({ revalidatePath }))
+vi.mock('next/headers', () => ({ headers }))
+
+import { signOut } from '../sign-out'
+
+describe('signOut', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+	})
+
+	it('signs out, revalidates, and redirects home', async () => {
+		await expect(signOut()).rejects.toThrow('NEXT_REDIRECT')
+		expect(signOutApi).toHaveBeenCalledOnce()
+		expect(revalidatePath).toHaveBeenCalledWith('/')
+		expect(redirect).toHaveBeenCalledWith('/')
+	})
+
+	it('throws a friendly error when sign out fails', async () => {
+		signOutApi.mockRejectedValueOnce(new Error('session error'))
+		await expect(signOut()).rejects.toThrow('Failed to sign out')
+		expect(redirect).not.toHaveBeenCalled()
+	})
+})

--- a/apps/www/src/actions/auth/__test__/sign-up.test.ts
+++ b/apps/www/src/actions/auth/__test__/sign-up.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { signUpEmail, revalidatePath, headers } = vi.hoisted(() => ({
+	signUpEmail: vi.fn(),
+	revalidatePath: vi.fn(),
+	headers: vi.fn(async () => new Headers()),
+}))
+
+vi.mock('@/lib/auth/auth', () => ({ auth: { api: { signUpEmail } } }))
+vi.mock('next/cache', () => ({ revalidatePath }))
+vi.mock('next/headers', () => ({ headers }))
+
+import { signUp } from '../sign-up'
+
+const formDataFor = (fields: Record<string, string>) => {
+	const fd = new FormData()
+	for (const [key, value] of Object.entries(fields)) fd.append(key, value)
+	return fd
+}
+
+describe('signUp', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+	})
+
+	it('throws when required fields are missing', async () => {
+		await expect(signUp(formDataFor({ email: 'a@b.com' }))).rejects.toThrow(
+			'Email, password, and name are required'
+		)
+		expect(signUpEmail).not.toHaveBeenCalled()
+	})
+
+	it('signs the user up, revalidates, and returns success', async () => {
+		const fd = formDataFor({
+			email: 'a@b.com',
+			password: 'secret123',
+			name: 'Ada',
+		})
+		const result = await signUp(fd)
+
+		expect(signUpEmail).toHaveBeenCalledWith({
+			headers: expect.any(Headers),
+			body: { email: 'a@b.com', password: 'secret123', name: 'Ada' },
+		})
+		expect(revalidatePath).toHaveBeenCalledWith('/')
+		expect(result).toEqual({ success: true, email: 'a@b.com' })
+	})
+
+	it('maps USER_ALREADY_EXISTS to a friendly error', async () => {
+		signUpEmail.mockRejectedValueOnce({ body: { code: 'USER_ALREADY_EXISTS' } })
+		await expect(
+			signUp(formDataFor({ email: 'a@b.com', password: 'secret123', name: 'Ada' }))
+		).rejects.toThrow('A user with this email already exists')
+	})
+
+	it('rethrows unexpected errors', async () => {
+		signUpEmail.mockRejectedValueOnce(new Error('boom'))
+		await expect(
+			signUp(formDataFor({ email: 'a@b.com', password: 'secret123', name: 'Ada' }))
+		).rejects.toThrow('boom')
+	})
+})

--- a/apps/www/src/actions/auth/__test__/update-password.test.ts
+++ b/apps/www/src/actions/auth/__test__/update-password.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+	getSession,
+	findAccountByUserId,
+	updatePassword,
+	verify,
+	hash,
+	headers,
+} = vi.hoisted(() => ({
+	getSession: vi.fn(),
+	findAccountByUserId: vi.fn(),
+	updatePassword: vi.fn(),
+	verify: vi.fn(),
+	hash: vi.fn(),
+	headers: vi.fn(async () => new Headers()),
+}))
+
+vi.mock('@/lib/auth/auth', () => ({
+	auth: {
+		api: { getSession },
+		$context: Promise.resolve({
+			internalAdapter: { findAccountByUserId, updatePassword },
+			password: { verify, hash },
+		}),
+	},
+}))
+vi.mock('next/headers', () => ({ headers }))
+
+import { updatePasswordAction } from '../update-password'
+
+const sessionUser = { user: { id: 'user-1' } }
+
+describe('updatePasswordAction', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+	})
+
+	it('errors when there is no session', async () => {
+		getSession.mockResolvedValueOnce(null)
+		const result = await updatePasswordAction({ newPassword: 'NewPass1!' })
+		expect(result).toEqual({
+			error: 'You must be signed in to update your password',
+		})
+	})
+
+	it('errors when the user has no accounts', async () => {
+		getSession.mockResolvedValueOnce(sessionUser)
+		findAccountByUserId.mockResolvedValueOnce([])
+		const result = await updatePasswordAction({ newPassword: 'NewPass1!' })
+		expect(result).toEqual({
+			error: 'No account found. Please try signing in again.',
+		})
+	})
+
+	it('requires the current password when an account has one', async () => {
+		getSession.mockResolvedValueOnce(sessionUser)
+		findAccountByUserId.mockResolvedValueOnce([{ password: 'existing-hash' }])
+		const result = await updatePasswordAction({ newPassword: 'NewPass1!' })
+		expect(result).toEqual({ error: 'Current password is required' })
+	})
+
+	it('rejects an incorrect current password', async () => {
+		getSession.mockResolvedValueOnce(sessionUser)
+		findAccountByUserId.mockResolvedValueOnce([{ password: 'existing-hash' }])
+		verify.mockResolvedValueOnce(false)
+		const result = await updatePasswordAction({
+			currentPassword: 'wrong',
+			newPassword: 'NewPass1!',
+		})
+		expect(result).toEqual({ error: 'Current password is incorrect' })
+	})
+
+	it('updates the password on the happy path', async () => {
+		getSession.mockResolvedValueOnce(sessionUser)
+		findAccountByUserId.mockResolvedValueOnce([{ password: 'existing-hash' }])
+		verify.mockResolvedValueOnce(true)
+		hash.mockResolvedValueOnce('new-hash')
+		const result = await updatePasswordAction({
+			currentPassword: 'correct',
+			newPassword: 'NewPass1!',
+		})
+		expect(hash).toHaveBeenCalledWith('NewPass1!')
+		expect(updatePassword).toHaveBeenCalledWith('user-1', 'new-hash')
+		expect(result).toEqual({ success: true })
+	})
+
+	it('skips verification for an account without a password', async () => {
+		getSession.mockResolvedValueOnce(sessionUser)
+		findAccountByUserId.mockResolvedValueOnce([{ password: null }])
+		hash.mockResolvedValueOnce('new-hash')
+		const result = await updatePasswordAction({ newPassword: 'NewPass1!' })
+		expect(verify).not.toHaveBeenCalled()
+		expect(updatePassword).toHaveBeenCalledWith('user-1', 'new-hash')
+		expect(result).toEqual({ success: true })
+	})
+})

--- a/apps/www/src/actions/email/__test__/create-contact.test.ts
+++ b/apps/www/src/actions/email/__test__/create-contact.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { contactsCreate } = vi.hoisted(() => ({ contactsCreate: vi.fn() }))
+
+vi.mock('resend', () => ({
+	Resend: vi.fn(function () {
+		return { contacts: { create: contactsCreate } }
+	}),
+}))
+
+import { createContact } from '../create-contact'
+
+const contact = {
+	firstName: 'Ada',
+	lastName: 'Lovelace',
+	email: 'ada@example.com',
+}
+
+describe('createContact', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'log').mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		vi.unstubAllEnvs()
+	})
+
+	it('throws when no audience id is available', async () => {
+		vi.stubEnv('RESEND_DEFAULT_AUDIENCE_ID', '')
+		await expect(createContact(contact)).rejects.toThrow(
+			'No audience ID provided and RESEND_DEFAULT_AUDIENCE_ID not configured'
+		)
+	})
+
+	it('uses the explicit audience id when provided', async () => {
+		contactsCreate.mockResolvedValueOnce({ data: { id: 'c1' } })
+		await createContact({ ...contact, audienceId: 'explicit_aud' })
+		expect(contactsCreate).toHaveBeenCalledWith({
+			email: 'ada@example.com',
+			audienceId: 'explicit_aud',
+			firstName: 'Ada',
+			lastName: 'Lovelace',
+			unsubscribed: false,
+		})
+	})
+
+	it('falls back to the default audience id from env', async () => {
+		vi.stubEnv('RESEND_DEFAULT_AUDIENCE_ID', 'default_aud')
+		contactsCreate.mockResolvedValueOnce({ data: { id: 'c1' } })
+		await createContact(contact)
+		expect(contactsCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ audienceId: 'default_aud' })
+		)
+	})
+
+	it('throws a friendly error when creation fails', async () => {
+		contactsCreate.mockRejectedValueOnce(new Error('api down'))
+		await expect(
+			createContact({ ...contact, audienceId: 'explicit_aud' })
+		).rejects.toThrow('Failed to create contact')
+	})
+})

--- a/apps/www/src/actions/email/__test__/delete-contact.test.ts
+++ b/apps/www/src/actions/email/__test__/delete-contact.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { contactsRemove } = vi.hoisted(() => ({ contactsRemove: vi.fn() }))
+
+vi.mock('resend', () => ({
+	Resend: vi.fn(function () {
+		return { contacts: { remove: contactsRemove } }
+	}),
+}))
+
+import { deleteContact } from '../delete-contact'
+
+describe('deleteContact', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'log').mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		vi.unstubAllEnvs()
+	})
+
+	it('throws when no audience id is available', async () => {
+		vi.stubEnv('RESEND_DEFAULT_AUDIENCE_ID', '')
+		await expect(
+			deleteContact({ email: 'user@example.com' })
+		).rejects.toThrow(
+			'No audience ID provided and RESEND_DEFAULT_AUDIENCE_ID not configured'
+		)
+		expect(contactsRemove).not.toHaveBeenCalled()
+	})
+
+	it('removes the contact from the given audience', async () => {
+		contactsRemove.mockResolvedValueOnce({ data: { deleted: true } })
+		await deleteContact({ email: 'user@example.com', audienceId: 'aud_1' })
+		expect(contactsRemove).toHaveBeenCalledWith({
+			email: 'user@example.com',
+			audienceId: 'aud_1',
+		})
+	})
+
+	it('throws a friendly error when removal fails', async () => {
+		contactsRemove.mockRejectedValueOnce(new Error('api down'))
+		await expect(
+			deleteContact({ email: 'user@example.com', audienceId: 'aud_1' })
+		).rejects.toThrow('Failed to delete contact')
+	})
+})

--- a/apps/www/src/actions/email/__test__/file-download.test.ts
+++ b/apps/www/src/actions/email/__test__/file-download.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { emailsSend } = vi.hoisted(() => ({ emailsSend: vi.fn() }))
+
+vi.mock('resend', () => ({
+	Resend: vi.fn(function () {
+		return { emails: { send: emailsSend } }
+	}),
+}))
+vi.mock('../../../../../packages/email/emails/file-download', () => ({
+	default: vi.fn(() => null),
+}))
+
+import { sendFileDownload } from '../file-download'
+
+const payload = {
+	email: 'user@example.com',
+	file: 'https://files.example.com/cheatsheet.pdf',
+	title: 'Rhythm Cheatsheet',
+}
+
+describe('sendFileDownload', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'log').mockImplementation(() => {})
+	})
+
+	it('sends the download email to the requester', async () => {
+		emailsSend.mockResolvedValueOnce({ data: { id: 'e1' } })
+		await sendFileDownload(payload)
+		expect(emailsSend).toHaveBeenCalledWith(
+			expect.objectContaining({
+				from: 'Downbeat Academy <hello@email.downbeatacademy.com>',
+				to: 'user@example.com',
+				subject: '🎼 Your download from Downbeat Academy is here!',
+				replyTo: 'jory@downbeatacademy.com',
+			})
+		)
+	})
+
+	it('throws when sending fails', async () => {
+		emailsSend.mockRejectedValueOnce(new Error('api down'))
+		await expect(sendFileDownload(payload)).rejects.toThrow(
+			'Failed to send email'
+		)
+	})
+})

--- a/apps/www/src/actions/email/__test__/newsletter-subscription.test.ts
+++ b/apps/www/src/actions/email/__test__/newsletter-subscription.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { contactsCreate } = vi.hoisted(() => ({ contactsCreate: vi.fn() }))
+
+vi.mock('resend', () => ({
+	Resend: vi.fn(function () {
+		return { contacts: { create: contactsCreate } }
+	}),
+}))
+
+import { subscribeToNewsletter } from '../newsletter-subscription'
+
+describe('subscribeToNewsletter', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'log').mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		vi.unstubAllEnvs()
+	})
+
+	it('throws when the default audience is not configured', async () => {
+		vi.stubEnv('RESEND_DEFAULT_AUDIENCE_ID', '')
+		await expect(
+			subscribeToNewsletter({ email: 'user@example.com' })
+		).rejects.toThrow('RESEND_DEFAULT_AUDIENCE_ID not configured')
+		expect(contactsCreate).not.toHaveBeenCalled()
+	})
+
+	it('creates a contact in the configured audience', async () => {
+		vi.stubEnv('RESEND_DEFAULT_AUDIENCE_ID', 'aud_123')
+		contactsCreate.mockResolvedValueOnce({ data: { id: 'c1' } })
+		await subscribeToNewsletter({ email: 'user@example.com' })
+		expect(contactsCreate).toHaveBeenCalledWith({
+			email: 'user@example.com',
+			unsubscribed: false,
+			audienceId: 'aud_123',
+		})
+	})
+
+	it('throws a friendly error when the API call fails', async () => {
+		vi.stubEnv('RESEND_DEFAULT_AUDIENCE_ID', 'aud_123')
+		contactsCreate.mockRejectedValueOnce(new Error('api down'))
+		await expect(
+			subscribeToNewsletter({ email: 'user@example.com' })
+		).rejects.toThrow('Failed to subscribe to newsletter')
+	})
+})

--- a/apps/www/src/actions/email/__test__/send-email.test.ts
+++ b/apps/www/src/actions/email/__test__/send-email.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { emailsSend } = vi.hoisted(() => ({ emailsSend: vi.fn() }))
+
+vi.mock('resend', () => ({
+	Resend: vi.fn(function () {
+		return { emails: { send: emailsSend } }
+	}),
+}))
+// The email template renders React Email components; stub it so importing the
+// action under test never pulls in the real rendering dependencies.
+vi.mock('../../../../../packages/email/emails/contact-form', () => ({
+	default: vi.fn(() => null),
+}))
+
+import { sendEmail } from '../send-email'
+
+const payload = {
+	name: 'Ada',
+	email: 'ada@example.com',
+	message: 'Hello!',
+}
+
+describe('sendEmail', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'log').mockImplementation(() => {})
+	})
+
+	it('sends the contact email with the expected envelope', async () => {
+		emailsSend.mockResolvedValueOnce({ data: { id: 'e1' } })
+		await sendEmail(payload)
+		expect(emailsSend).toHaveBeenCalledWith(
+			expect.objectContaining({
+				from: 'Downbeat Academy <hello@email.downbeatacademy.com>',
+				to: 'jory@downbeatacademy.com',
+				subject:
+					'Ada sent you a message from the Downbeat Academy contact form',
+				replyTo: 'ada@example.com',
+			})
+		)
+	})
+
+	it('throws when sending fails', async () => {
+		emailsSend.mockRejectedValueOnce(new Error('api down'))
+		await expect(sendEmail(payload)).rejects.toThrow('Failed to send email')
+	})
+})

--- a/apps/www/src/actions/profile/__test__/get-profile.test.ts
+++ b/apps/www/src/actions/profile/__test__/get-profile.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSession, headers } = vi.hoisted(() => ({
+	getSession: vi.fn(),
+	headers: vi.fn(async () => new Headers()),
+}))
+
+vi.mock('@/lib/auth/auth', () => ({ auth: { api: { getSession } } }))
+vi.mock('next/headers', () => ({ headers }))
+
+import { getProfile } from '../get-profile'
+
+describe('getProfile', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('throws when there is no session', async () => {
+		getSession.mockResolvedValueOnce(null)
+		await expect(getProfile()).rejects.toThrow('Not authenticated')
+	})
+
+	it('returns the user from the session', async () => {
+		const user = { id: 'u1', name: 'Ada', email: 'ada@example.com' }
+		getSession.mockResolvedValueOnce({ session: { id: 's1' }, user })
+		await expect(getProfile()).resolves.toEqual({ user })
+	})
+})

--- a/apps/www/src/actions/profile/__test__/update-profile.test.ts
+++ b/apps/www/src/actions/profile/__test__/update-profile.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSession, updateUser, headers } = vi.hoisted(() => ({
+	getSession: vi.fn(),
+	updateUser: vi.fn(),
+	headers: vi.fn(async () => new Headers()),
+}))
+
+vi.mock('@/lib/auth/auth', () => ({
+	auth: { api: { getSession, updateUser } },
+}))
+vi.mock('next/headers', () => ({ headers }))
+
+import { updateProfile } from '../update-profile'
+
+describe('updateProfile', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+	})
+
+	it('throws when there is no session', async () => {
+		getSession.mockResolvedValueOnce(null)
+		await expect(updateProfile({ name: 'Ada' })).rejects.toThrow(
+			'Not authenticated'
+		)
+		expect(updateUser).not.toHaveBeenCalled()
+	})
+
+	it('updates the user name and returns success', async () => {
+		getSession.mockResolvedValueOnce({ session: { id: 's1' } })
+		const result = await updateProfile({ name: 'Ada Lovelace' })
+		expect(updateUser).toHaveBeenCalledWith({
+			headers: expect.any(Headers),
+			body: { name: 'Ada Lovelace' },
+		})
+		expect(result).toEqual({ success: true })
+	})
+
+	it('rethrows update failures', async () => {
+		getSession.mockResolvedValueOnce({ session: { id: 's1' } })
+		updateUser.mockRejectedValueOnce(new Error('update failed'))
+		await expect(updateProfile({ name: 'Ada' })).rejects.toThrow('update failed')
+	})
+})

--- a/apps/www/src/components/music-notation/transfomers/__test__/transform-chord.test.tsx
+++ b/apps/www/src/components/music-notation/transfomers/__test__/transform-chord.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { transformChord } from '../transform-chord'
+
+const renderChord = (...args: Parameters<typeof transformChord>) =>
+	render(<>{transformChord(...args)}</>).container.textContent
+
+describe('transformChord', () => {
+	it('renders root, quality, extension, and alternate bass', () => {
+		expect(renderChord('C', 'major7', 'flat9', 'E', 'symbol')).toBe(
+			'Cmaj7(𝄭9)/E'
+		)
+	})
+
+	it('renders the root on its own when other parts are empty', () => {
+		expect(renderChord('G', '', '', '', 'symbol')).toBe('G')
+	})
+
+	it('renders the alternate bass as a slash chord', () => {
+		expect(renderChord('A', 'minor', '', 'C', 'abbr')).toBe('Amin/C')
+	})
+
+	it('treats abbr and symbol quality maps identically (current behavior)', () => {
+		expect(renderChord('D', 'minor7', '', '', 'abbr')).toBe('Dmin7')
+		expect(renderChord('D', 'minor7', '', '', 'symbol')).toBe('Dmin7')
+	})
+
+	it('omits the quality segment for an unsupported quality', () => {
+		// Documents the `getQuality` default fallthrough (returns undefined), so the
+		// quality renders as nothing rather than an error string.
+		expect(renderChord('C', 'unsupportedQuality', '', '', 'abbr')).toBe('C')
+	})
+})

--- a/apps/www/src/components/music-notation/transfomers/__test__/transform-primitive.test.tsx
+++ b/apps/www/src/components/music-notation/transfomers/__test__/transform-primitive.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { transformAccidental } from '../transform-primitive'
+
+describe('transformAccidental', () => {
+	it('maps known accidentals to their music symbols', () => {
+		expect(transformAccidental('flat')).toBe('𝄭')
+		expect(transformAccidental('double-flat')).toBe('𝄫')
+		expect(transformAccidental('double-sharp')).toBe('𝄪')
+		expect(transformAccidental('natural')).toBe('♮')
+	})
+
+	it('maps "sharp" to the sharp symbol', () => {
+		// Regression for the `case 'share'` typo: the public key is "sharp".
+		expect(transformAccidental('sharp')).toBe('𝄰')
+	})
+
+	it('returns null for an unsupported accidental', () => {
+		// Regression for the missing `return` in the default branch.
+		expect(transformAccidental('not-an-accidental')).toBeNull()
+	})
+})

--- a/apps/www/src/components/music-notation/transfomers/transform-primitive.tsx
+++ b/apps/www/src/components/music-notation/transfomers/transform-primitive.tsx
@@ -2,7 +2,7 @@ const transformAccidental = (value: string) => {
 	switch (value) {
 		case 'flat':
 			return '𝄭'
-		case 'share':
+		case 'sharp':
 			return '𝄰'
 		case 'double-flat':
 			return '𝄫'
@@ -11,7 +11,7 @@ const transformAccidental = (value: string) => {
 		case 'natural':
 			return '♮'
 		default:
-			'Unsupported accidental.'
+			return null
 	}
 }
 

--- a/apps/www/src/components/reading-length/__test__/calculateReadingLength.test.ts
+++ b/apps/www/src/components/reading-length/__test__/calculateReadingLength.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import calculateReadingLength from '../calculateReadingLength'
+
+describe('calculateReadingLength', () => {
+	it('returns 1 for empty or invalid content', () => {
+		expect(calculateReadingLength(null)).toBe(1)
+		expect(calculateReadingLength(undefined)).toBe(1)
+		expect(calculateReadingLength('')).toBe(1)
+	})
+
+	it('returns 1 for non-string, non-array content', () => {
+		// e.g. a number sneaking through — falls past the string and array guards.
+		expect(calculateReadingLength(42 as never)).toBe(1)
+	})
+
+	describe('string content', () => {
+		it('rounds up words / 200 with a minimum of 1', () => {
+			expect(calculateReadingLength('hello world')).toBe(1)
+			expect(calculateReadingLength(`${'word '.repeat(200).trim()}`)).toBe(1)
+			expect(calculateReadingLength(`${'word '.repeat(201).trim()}`)).toBe(2)
+			expect(calculateReadingLength(`${'word '.repeat(400).trim()}`)).toBe(2)
+		})
+
+		it('treats whitespace-only content as a single minute', () => {
+			expect(calculateReadingLength('     ')).toBe(1)
+		})
+	})
+
+	describe('block content', () => {
+		it('reads text from children arrays', () => {
+			const content = [
+				{ _type: 'block', children: [{ text: 'hello' }, { text: 'world' }] },
+			]
+			expect(calculateReadingLength(content)).toBe(1)
+		})
+
+		it('reads text from a singular child', () => {
+			expect(
+				calculateReadingLength([{ _type: 'block', child: { text: 'foo bar' } }])
+			).toBe(1)
+		})
+
+		it('reads text from a direct text property', () => {
+			expect(calculateReadingLength([{ _type: 'block', text: 'baz' }])).toBe(1)
+		})
+
+		it('ignores non-block nodes', () => {
+			const content = [
+				{ _type: 'image' },
+				{ _type: 'block', children: [{ text: 'just one block' }] },
+			]
+			expect(calculateReadingLength(content)).toBe(1)
+		})
+
+		it('returns 1 for an empty array', () => {
+			expect(calculateReadingLength([])).toBe(1)
+		})
+
+		it('rounds up long block content', () => {
+			const content = [
+				{
+					_type: 'block',
+					children: Array.from({ length: 201 }, () => ({ text: 'word' })),
+				},
+			]
+			expect(calculateReadingLength(content)).toBe(2)
+		})
+	})
+})

--- a/apps/www/src/lib/types/__test__/contact-form-schema.test.ts
+++ b/apps/www/src/lib/types/__test__/contact-form-schema.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { contactFormSchema } from '../contact-form-schema'
+
+const base = {
+	name: 'Ada Lovelace',
+	email: 'ada@example.com',
+	message: 'Hello there!',
+}
+
+const messages = (result: ReturnType<typeof contactFormSchema.safeParse>) =>
+	result.success ? [] : result.error.issues.map((i) => i.message)
+
+describe('contactFormSchema', () => {
+	it('accepts a fully populated form', () => {
+		// The trailing `.refine((data) => data.name && data.email && data.message)`
+		// is a redundant no-op here: the inner `.min(1)` checks already guarantee
+		// all three fields are non-empty, so the refine never adds a failure.
+		expect(contactFormSchema.safeParse(base).success).toBe(true)
+	})
+
+	it('requires a name', () => {
+		const result = contactFormSchema.safeParse({ ...base, name: '' })
+		expect(result.success).toBe(false)
+		expect(messages(result)).toContain('Name is required')
+	})
+
+	it('requires an email', () => {
+		const result = contactFormSchema.safeParse({ ...base, email: '' })
+		expect(result.success).toBe(false)
+		expect(messages(result)).toContain('Email is required')
+	})
+
+	it('requires a valid email format', () => {
+		const result = contactFormSchema.safeParse({ ...base, email: 'not-email' })
+		expect(result.success).toBe(false)
+	})
+
+	it('requires a message', () => {
+		const result = contactFormSchema.safeParse({ ...base, message: '' })
+		expect(result.success).toBe(false)
+		expect(messages(result)).toContain('Message is required')
+	})
+})

--- a/apps/www/src/lib/types/__test__/file-download-schema.test.ts
+++ b/apps/www/src/lib/types/__test__/file-download-schema.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { fileDownloadSchema } from '../file-download-schema'
+
+describe('fileDownloadSchema', () => {
+	it('accepts a valid email', () => {
+		// The trailing `.refine((data) => data.email)` is redundant once `.min(1)`
+		// and `.email()` have passed; documented here for completeness.
+		expect(
+			fileDownloadSchema.safeParse({ email: 'user@example.com' }).success
+		).toBe(true)
+	})
+
+	it('rejects an empty email', () => {
+		const result = fileDownloadSchema.safeParse({ email: '' })
+		expect(result.success).toBe(false)
+		expect(result.success ? [] : result.error.issues.map((i) => i.message)).toContain(
+			'Email is required'
+		)
+	})
+
+	it('rejects an invalid email format', () => {
+		expect(fileDownloadSchema.safeParse({ email: 'nope' }).success).toBe(false)
+	})
+})

--- a/apps/www/src/lib/types/__test__/newsletter-signup-schema.test.ts
+++ b/apps/www/src/lib/types/__test__/newsletter-signup-schema.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { newsletterSignupSchema } from '../newsletter-signup-schema'
+
+describe('newsletterSignupSchema', () => {
+	it('accepts a valid email', () => {
+		// `.refine((data) => data.email)` is a no-op once `.email()` passes.
+		expect(
+			newsletterSignupSchema.safeParse({ email: 'user@example.com' }).success
+		).toBe(true)
+	})
+
+	it('rejects an invalid email', () => {
+		expect(newsletterSignupSchema.safeParse({ email: 'nope' }).success).toBe(
+			false
+		)
+	})
+
+	it('rejects an empty email', () => {
+		expect(newsletterSignupSchema.safeParse({ email: '' }).success).toBe(false)
+	})
+})

--- a/apps/www/src/lib/types/auth/__test__/login-form-schema.test.ts
+++ b/apps/www/src/lib/types/auth/__test__/login-form-schema.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { loginSchema } from '../login-form-schema'
+
+const messages = (result: ReturnType<typeof loginSchema.safeParse>) =>
+	result.success ? [] : result.error.issues.map((i) => i.message)
+
+describe('loginSchema', () => {
+	it('accepts a valid email and password', () => {
+		const result = loginSchema.safeParse({
+			email: 'user@example.com',
+			password: 'password123',
+		})
+		expect(result.success).toBe(true)
+	})
+
+	it('rejects an invalid email format', () => {
+		const result = loginSchema.safeParse({
+			email: 'not-an-email',
+			password: 'password123',
+		})
+		expect(result.success).toBe(false)
+		expect(messages(result)).toContain('Invalid email address')
+	})
+
+	it('rejects an empty email', () => {
+		const result = loginSchema.safeParse({ email: '', password: 'password123' })
+		expect(result.success).toBe(false)
+	})
+
+	it('rejects a password shorter than 8 characters', () => {
+		const result = loginSchema.safeParse({
+			email: 'user@example.com',
+			password: '1234567',
+		})
+		expect(result.success).toBe(false)
+		expect(messages(result)).toContain('Password must be at least 8 characters')
+	})
+
+	it('rejects an empty password', () => {
+		const result = loginSchema.safeParse({
+			email: 'user@example.com',
+			password: '',
+		})
+		expect(result.success).toBe(false)
+		expect(messages(result)).toContain('Password is required')
+	})
+})

--- a/apps/www/src/lib/types/auth/__test__/reset-password-schema.test.ts
+++ b/apps/www/src/lib/types/auth/__test__/reset-password-schema.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { resetPasswordSchema } from '../reset-password-schema'
+
+describe('resetPasswordSchema', () => {
+	it('accepts a valid email', () => {
+		expect(
+			resetPasswordSchema.safeParse({ email: 'user@example.com' }).success
+		).toBe(true)
+	})
+
+	it('rejects an invalid email', () => {
+		const result = resetPasswordSchema.safeParse({ email: 'nope' })
+		expect(result.success).toBe(false)
+		expect(result.success ? [] : result.error.issues.map((i) => i.message)).toContain(
+			'Invalid email address'
+		)
+	})
+
+	it('rejects an empty email', () => {
+		expect(resetPasswordSchema.safeParse({ email: '' }).success).toBe(false)
+	})
+})

--- a/apps/www/src/lib/types/auth/__test__/sign-up-form-schema.test.ts
+++ b/apps/www/src/lib/types/auth/__test__/sign-up-form-schema.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { signUpFormSchema } from '../sign-up-form-schema'
+
+const base = {
+	email: 'user@example.com',
+	name: 'Ada Lovelace',
+	password: 'Abcdef1!',
+	confirmPassword: 'Abcdef1!',
+}
+
+const issuesFor = (result: ReturnType<typeof signUpFormSchema.safeParse>) =>
+	result.success ? [] : result.error.issues
+
+describe('signUpFormSchema', () => {
+	it('accepts a fully valid sign-up payload', () => {
+		expect(signUpFormSchema.safeParse(base).success).toBe(true)
+	})
+
+	it('rejects an invalid email with a friendly message', () => {
+		const result = signUpFormSchema.safeParse({ ...base, email: 'nope' })
+		expect(result.success).toBe(false)
+		expect(issuesFor(result).map((i) => i.message)).toContain(
+			'Please enter a valid email address'
+		)
+	})
+
+	it('rejects an empty name', () => {
+		const result = signUpFormSchema.safeParse({ ...base, name: '' })
+		expect(result.success).toBe(false)
+		expect(issuesFor(result).map((i) => i.message)).toContain(
+			'Please enter your name'
+		)
+	})
+
+	it('flags mismatched passwords on the confirmPassword path', () => {
+		const result = signUpFormSchema.safeParse({
+			...base,
+			confirmPassword: 'Different1!',
+		})
+		expect(result.success).toBe(false)
+		const issue = issuesFor(result).find((i) => i.path[0] === 'confirmPassword')
+		expect(issue?.message).toBe("Passwords don't match")
+	})
+
+	it('rejects a password shorter than 8 characters', () => {
+		const result = signUpFormSchema.safeParse({
+			...base,
+			password: 'Ab1!',
+			confirmPassword: 'Ab1!',
+		})
+		expect(result.success).toBe(false)
+		expect(issuesFor(result).map((i) => i.message)).toContain(
+			'Password must be at least 8 characters'
+		)
+	})
+
+	describe('password complexity (superRefine)', () => {
+		const complexityMessage =
+			'Password must include at least one uppercase letter, one lowercase letter, one number, and one special character.'
+
+		const expectComplexityFailure = (password: string) => {
+			const result = signUpFormSchema.safeParse({
+				...base,
+				password,
+				confirmPassword: password,
+			})
+			expect(result.success).toBe(false)
+			const issue = issuesFor(result).find((i) => i.path[0] === 'password')
+			expect(issue?.message).toBe(complexityMessage)
+		}
+
+		it('requires an uppercase letter', () => expectComplexityFailure('abcdef1!'))
+		it('requires a lowercase letter', () => expectComplexityFailure('ABCDEF1!'))
+		it('requires a number', () => expectComplexityFailure('Abcdefg!'))
+		it('requires a special character', () => expectComplexityFailure('Abcdefg1'))
+	})
+
+	it('documents that a space is counted as a number by the complexity check', () => {
+		// `!isNaN(+ch)` treats a space as 0 (a number), so a space satisfies the
+		// "contains a number" rule even though there is no digit. This is a latent
+		// quirk in the validator preserved here intentionally.
+		const password = 'Abcdef !'
+		const result = signUpFormSchema.safeParse({
+			...base,
+			password,
+			confirmPassword: password,
+		})
+		expect(result.success).toBe(true)
+	})
+})

--- a/apps/www/src/lib/types/auth/__test__/update-email-schema.test.ts
+++ b/apps/www/src/lib/types/auth/__test__/update-email-schema.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { updateEmailSchema } from '../update-email-schema'
+
+describe('updateEmailSchema', () => {
+	it('accepts a valid email', () => {
+		expect(
+			updateEmailSchema.safeParse({ email: 'user@example.com' }).success
+		).toBe(true)
+	})
+
+	it('rejects an invalid email', () => {
+		expect(updateEmailSchema.safeParse({ email: 'bad' }).success).toBe(false)
+	})
+
+	it('rejects an empty email', () => {
+		expect(updateEmailSchema.safeParse({ email: '' }).success).toBe(false)
+	})
+})

--- a/apps/www/src/lib/types/auth/__test__/update-password-schema.test.ts
+++ b/apps/www/src/lib/types/auth/__test__/update-password-schema.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { updatePasswordSchema } from '../update-password-schema'
+
+const base = {
+	newPassword: 'Abcdef1!',
+	confirmNewPassword: 'Abcdef1!',
+}
+
+const issuesFor = (result: ReturnType<typeof updatePasswordSchema.safeParse>) =>
+	result.success ? [] : result.error.issues
+
+describe('updatePasswordSchema', () => {
+	it('accepts a valid, matching, complex password', () => {
+		expect(updatePasswordSchema.safeParse(base).success).toBe(true)
+	})
+
+	it('maps the mismatch error to the confirmNewPassword field', () => {
+		// Regression for the refine path fix: the error must point at the real field
+		// (`confirmNewPassword`), not the non-existent `confirmPassword`.
+		const result = updatePasswordSchema.safeParse({
+			...base,
+			confirmNewPassword: 'Different1!',
+		})
+		expect(result.success).toBe(false)
+		const issue = issuesFor(result).find(
+			(i) => i.message === 'Passwords do not match'
+		)
+		expect(issue?.path).toEqual(['confirmNewPassword'])
+	})
+
+	it('enforces password complexity on newPassword', () => {
+		const result = updatePasswordSchema.safeParse({
+			newPassword: 'abcdefg1',
+			confirmNewPassword: 'abcdefg1',
+		})
+		expect(result.success).toBe(false)
+		const issue = issuesFor(result).find((i) => i.path[0] === 'newPassword')
+		expect(issue?.message).toContain('Password must include')
+	})
+})

--- a/apps/www/src/lib/types/auth/__test__/update-user-schema.test.ts
+++ b/apps/www/src/lib/types/auth/__test__/update-user-schema.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { updateUserSchema } from '../update-user-schema'
+
+describe('updateUserSchema', () => {
+	it('accepts a valid email and password', () => {
+		const result = updateUserSchema.safeParse({
+			email: 'user@example.com',
+			password: 'password123',
+		})
+		expect(result.success).toBe(true)
+	})
+
+	it('rejects a password shorter than 8 characters', () => {
+		const result = updateUserSchema.safeParse({
+			email: 'user@example.com',
+			password: 'short',
+		})
+		expect(result.success).toBe(false)
+		expect(result.success ? [] : result.error.issues.map((i) => i.message)).toContain(
+			'Password must be at least 8 characters'
+		)
+	})
+
+	it('rejects an invalid email', () => {
+		const result = updateUserSchema.safeParse({
+			email: 'nope',
+			password: 'password123',
+		})
+		expect(result.success).toBe(false)
+	})
+})

--- a/apps/www/src/lib/types/auth/update-password-schema.ts
+++ b/apps/www/src/lib/types/auth/update-password-schema.ts
@@ -7,7 +7,7 @@ export const updatePasswordSchema = z
 	})
 	.refine((data) => data.newPassword === data.confirmNewPassword, {
 		message: 'Passwords do not match',
-		path: ['confirmPassword'],
+		path: ['confirmNewPassword'],
 	})
 	.superRefine(({ newPassword }, checkPassComplexity) => {
 		const containsUppercase = (ch: string) => /[A-Z]/.test(ch)

--- a/apps/www/src/lib/types/email/__test__/subscribe-to-newsletter-schema.test.ts
+++ b/apps/www/src/lib/types/email/__test__/subscribe-to-newsletter-schema.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { subscribeToNewsletterSchema } from '../subscribe-to-newsletter-schema'
+
+const messages = (
+	result: ReturnType<typeof subscribeToNewsletterSchema.safeParse>
+) => (result.success ? [] : result.error.issues.map((i) => i.message))
+
+describe('subscribeToNewsletterSchema', () => {
+	it('accepts a valid email', () => {
+		expect(
+			subscribeToNewsletterSchema.safeParse({ email: 'user@example.com' })
+				.success
+		).toBe(true)
+	})
+
+	it('rejects an empty email with the required message', () => {
+		const result = subscribeToNewsletterSchema.safeParse({ email: '' })
+		expect(result.success).toBe(false)
+		expect(messages(result)).toContain('Email is required')
+	})
+
+	it('rejects an invalid email with the invalid message', () => {
+		const result = subscribeToNewsletterSchema.safeParse({ email: 'nope' })
+		expect(result.success).toBe(false)
+		expect(messages(result)).toContain('Invalid email address')
+	})
+})

--- a/apps/www/src/lib/types/profile/__test__/update-profile-schema.test.ts
+++ b/apps/www/src/lib/types/profile/__test__/update-profile-schema.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { updateProfileSchema } from '../update-profile-schema'
+
+describe('updateProfileSchema', () => {
+	it('accepts any string name, including an empty string', () => {
+		// `name` is an unconstrained `z.string()`, so empty is currently valid.
+		expect(updateProfileSchema.safeParse({ name: 'Ada' }).success).toBe(true)
+		expect(updateProfileSchema.safeParse({ name: '' }).success).toBe(true)
+	})
+
+	it('rejects a non-string name', () => {
+		const result = updateProfileSchema.safeParse({ name: 123 as unknown as string })
+		expect(result.success).toBe(false)
+	})
+
+	it('rejects a missing name', () => {
+		const result = updateProfileSchema.safeParse({})
+		expect(result.success).toBe(false)
+	})
+})

--- a/apps/www/src/utils/__test__/dateFormat.test.ts
+++ b/apps/www/src/utils/__test__/dateFormat.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { prettyDate } from '../dateFormat'
+
+describe('prettyDate', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('formats a valid ISO date with the default format', () => {
+		expect(prettyDate('2026-06-10')).toBe('June 10th, 2026')
+	})
+
+	it('honors a custom format string', () => {
+		expect(prettyDate('2026-06-10', 'yyyy-MM-dd')).toBe('2026-06-10')
+		expect(prettyDate('2026-06-10', 'MMM yyyy')).toBe('Jun 2026')
+	})
+
+	it('returns an empty string for falsy input', () => {
+		expect(prettyDate('')).toBe('')
+		expect(prettyDate(null)).toBe('')
+		expect(prettyDate(undefined)).toBe('')
+	})
+
+	it('returns an empty string and logs for an unparseable date', () => {
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		expect(prettyDate('not-a-date')).toBe('')
+		expect(errorSpy).toHaveBeenCalled()
+	})
+
+	it('renders correct ordinal suffixes across boundaries', () => {
+		expect(prettyDate('2026-06-01')).toBe('June 1st, 2026')
+		expect(prettyDate('2026-06-02')).toBe('June 2nd, 2026')
+		expect(prettyDate('2026-06-03')).toBe('June 3rd, 2026')
+		expect(prettyDate('2026-06-11')).toBe('June 11th, 2026')
+		expect(prettyDate('2026-06-21')).toBe('June 21st, 2026')
+	})
+
+	it('handles a leap day', () => {
+		expect(prettyDate('2024-02-29')).toBe('February 29th, 2024')
+	})
+})

--- a/apps/www/src/utils/__test__/deslugify.test.ts
+++ b/apps/www/src/utils/__test__/deslugify.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { deslugify } from '../deslugify'
+
+describe('deslugify', () => {
+	it('converts a slug to a spaced string and a sentence-cased variant', () => {
+		expect(deslugify('hello-world')).toEqual({
+			string: 'hello world',
+			sentence: 'Hello world',
+		})
+	})
+
+	it('capitalizes only the first word for the sentence form', () => {
+		expect(deslugify('the-quick-brown-fox')).toEqual({
+			string: 'the quick brown fox',
+			sentence: 'The quick brown fox',
+		})
+	})
+
+	it('handles a single-word slug', () => {
+		expect(deslugify('single')).toEqual({
+			string: 'single',
+			sentence: 'Single',
+		})
+	})
+
+	it('returns empty strings for falsy input', () => {
+		expect(deslugify('')).toEqual({ string: '', sentence: '' })
+		// @ts-expect-error exercising the runtime guard with a nullish value
+		expect(deslugify(undefined)).toEqual({ string: '', sentence: '' })
+	})
+
+	it('preserves empty segments created by consecutive hyphens', () => {
+		expect(deslugify('a--b')).toEqual({
+			string: 'a  b',
+			sentence: 'A  b',
+		})
+	})
+})

--- a/apps/www/src/utils/__test__/format-time.test.ts
+++ b/apps/www/src/utils/__test__/format-time.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { formatTime } from '../format-time'
+
+describe('formatTime', () => {
+	it('formats zero seconds with a zero-padded seconds field', () => {
+		expect(formatTime(0)).toEqual({
+			minutes: 0,
+			totalSeconds: 0,
+			seconds: 0,
+			remainingSeconds: 0,
+			totalTime: '0:00',
+			totalTimeToString: '0-00',
+		})
+	})
+
+	it('zero-pads single-digit seconds', () => {
+		expect(formatTime(65)).toEqual({
+			minutes: 1,
+			totalSeconds: 65,
+			seconds: 5,
+			remainingSeconds: 5,
+			totalTime: '1:05',
+			totalTimeToString: '1-05',
+		})
+	})
+
+	it('formats exact minute boundaries', () => {
+		expect(formatTime(60).totalTime).toBe('1:00')
+		expect(formatTime(600).totalTime).toBe('10:00')
+	})
+
+	it('formats the seconds boundary around 10 and 60', () => {
+		expect(formatTime(59).totalTime).toBe('0:59')
+		expect(formatTime(61).totalTime).toBe('1:01')
+		expect(formatTime(9).totalTime).toBe('0:09')
+		expect(formatTime(10).totalTime).toBe('0:10')
+	})
+
+	it('exposes remainingSeconds equal to seconds (the field carries no extra padding)', () => {
+		// Documents the dead `remainingSeconds` computation: `0 + (s % 60)` is a no-op,
+		// so padding is applied only inside the template literal, not this field.
+		expect(formatTime(5).remainingSeconds).toBe(5)
+		expect(formatTime(5).seconds).toBe(5)
+	})
+})

--- a/apps/www/src/utils/__test__/getSanityImage.test.ts
+++ b/apps/www/src/utils/__test__/getSanityImage.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// The source builds its image-url builder at module load from the Sanity client,
+// so both the client and the builder factory must be mocked before import.
+const { imageSpy } = vi.hoisted(() => ({
+	imageSpy: vi.fn((source: unknown) => `image:${JSON.stringify(source)}`),
+}))
+
+vi.mock('@lib/sanity/sanity.client', () => ({
+	sanityClient: { config: () => ({ projectId: 'test', dataset: 'test' }) },
+}))
+
+vi.mock('@sanity/image-url', () => ({
+	default: () => ({ image: imageSpy }),
+}))
+
+import { getSanityImageUrl } from '../getSanityImage'
+
+describe('getSanityImageUrl', () => {
+	it('delegates to the image-url builder and returns its result', () => {
+		const source = { asset: { _ref: 'image-abc-100x100-png' } }
+		const result = getSanityImageUrl(source)
+		expect(imageSpy).toHaveBeenCalledWith(source)
+		expect(result).toBe(`image:${JSON.stringify(source)}`)
+	})
+})

--- a/apps/www/src/utils/__test__/getSanityUrl.test.ts
+++ b/apps/www/src/utils/__test__/getSanityUrl.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { parseAssetId, buildFileUrl } = vi.hoisted(() => ({
+	parseAssetId: vi.fn(() => ({ assetId: 'abc', extension: 'pdf' })),
+	buildFileUrl: vi.fn(() => 'https://cdn.sanity.io/files/p/d/abc.pdf'),
+}))
+
+vi.mock('@sanity/asset-utils', () => ({ parseAssetId, buildFileUrl }))
+vi.mock('@lib/sanity/sanity.config', () => ({
+	sanityConfig: { projectId: 'p', dataset: 'd' },
+}))
+
+import { getSanityUrl } from '../getSanityUrl'
+
+describe('getSanityUrl', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns null for a falsy asset id without touching the asset utils', () => {
+		expect(getSanityUrl('')).toBeNull()
+		expect(parseAssetId).not.toHaveBeenCalled()
+		expect(buildFileUrl).not.toHaveBeenCalled()
+	})
+
+	it('parses the asset id and builds the file url from config', () => {
+		const result = getSanityUrl('file-abc-pdf')
+		expect(parseAssetId).toHaveBeenCalledWith('file-abc-pdf')
+		expect(buildFileUrl).toHaveBeenCalledWith(
+			{ assetId: 'abc', extension: 'pdf' },
+			{ projectId: 'p', dataset: 'd' }
+		)
+		expect(result).toBe('https://cdn.sanity.io/files/p/d/abc.pdf')
+	})
+})

--- a/apps/www/src/utils/__test__/link-resolver.test.ts
+++ b/apps/www/src/utils/__test__/link-resolver.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { linkResolver } from '../link-resolver'
+
+describe('linkResolver', () => {
+	it('maps each known category to its route prefix', () => {
+		expect(linkResolver('home', 'page')).toBe('/home')
+		expect(linkResolver('my-post', 'article')).toBe('/articles/my-post')
+		expect(linkResolver('jazz', 'category')).toBe('/categories/jazz')
+		expect(linkResolver('john', 'contributor')).toBe('/contributors/john')
+		expect(linkResolver('jane', 'person')).toBe('/contributors/jane')
+		expect(linkResolver('ep-1', 'podcast')).toBe('/podcasts/ep-1')
+		expect(linkResolver('cheatsheet', 'resource')).toBe('/resources/cheatsheet')
+		expect(linkResolver('promo', 'landingPage')).toBe('/p/promo')
+		expect(linkResolver('intro', 'handbook')).toBe('/handbook/intro')
+		expect(linkResolver('cadence', 'lexicon')).toBe('/lexicon/cadence')
+	})
+
+	it('resolves the category route via the single canonical case', () => {
+		// Regression guard for the removed duplicate `case 'category'`: there must be
+		// exactly one reachable mapping and it must still resolve correctly.
+		expect(linkResolver('rhythm', 'category')).toBe('/categories/rhythm')
+	})
+
+	it('returns "/" when the url is falsy', () => {
+		expect(linkResolver('', 'article')).toBe('/')
+	})
+
+	it('returns the bare url for an unknown category', () => {
+		expect(linkResolver('whatever', 'unknown')).toBe('whatever')
+	})
+})

--- a/apps/www/src/utils/__test__/metaHelpers.test.ts
+++ b/apps/www/src/utils/__test__/metaHelpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { getOgTitle, limitDescription } from '../metaHelpers'
+
+describe('getOgTitle', () => {
+	it('appends the Downbeat Academy suffix', () => {
+		expect(getOgTitle('Learning Rhythm')).toBe(
+			'Learning Rhythm ♪ Downbeat Academy'
+		)
+	})
+
+	it('handles an empty title', () => {
+		expect(getOgTitle('')).toBe(' ♪ Downbeat Academy')
+	})
+})
+
+describe('limitDescription', () => {
+	it('returns short descriptions unchanged', () => {
+		const short = 'A concise description.'
+		expect(limitDescription(short)).toBe(short)
+	})
+
+	it('returns an empty string unchanged', () => {
+		expect(limitDescription('')).toBe('')
+	})
+
+	it('truncates descriptions longer than 200 characters to 200 characters', () => {
+		const long = 'a'.repeat(250)
+		const result = limitDescription(long)
+		expect(result).toHaveLength(200)
+		expect(result).toBe('a'.repeat(200))
+	})
+
+	it('keeps a description of exactly 200 characters unchanged', () => {
+		const exact = 'b'.repeat(200)
+		expect(limitDescription(exact)).toBe(exact)
+	})
+})

--- a/apps/www/src/utils/__test__/slugify.test.ts
+++ b/apps/www/src/utils/__test__/slugify.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { slugify } from '../slugify'
+
+describe('slugify', () => {
+	it('lowercases and joins words with dashes', () => {
+		expect(slugify(['Hello World'])).toBe('hello-world')
+		expect(slugify(['Hello', 'World'])).toBe('hello-world')
+	})
+
+	it('trims surrounding whitespace', () => {
+		expect(slugify(['  Padded  '])).toBe('padded')
+	})
+
+	it('strips disallowed special characters', () => {
+		expect(slugify(['Hello, World!'])).toBe('hello-world')
+	})
+
+	it('collapses runs of internal whitespace into a single dash', () => {
+		expect(slugify(['a   b'])).toBe('a-b')
+	})
+
+	it('preserves numbers and existing hyphens', () => {
+		expect(slugify(['Track 01'])).toBe('track-01')
+		expect(slugify(['well-known'])).toBe('well-known')
+	})
+
+	it('strips accented characters down to their ASCII-safe remainder', () => {
+		// é is not in [a-z0-9 -] so it is removed entirely (no transliteration).
+		expect(slugify(['café'])).toBe('caf')
+	})
+
+	it('returns an empty string for an empty array or empty members', () => {
+		expect(slugify([])).toBe('')
+		expect(slugify([''])).toBe('')
+	})
+})

--- a/apps/www/src/utils/__test__/stringFormat.test.ts
+++ b/apps/www/src/utils/__test__/stringFormat.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { toKebabCase } from '../stringFormat'
+
+describe('toKebabCase', () => {
+	it('converts camelCase to kebab-case', () => {
+		expect(toKebabCase('camelCase')).toBe('camel-case')
+	})
+
+	it('converts PascalCase to kebab-case', () => {
+		expect(toKebabCase('PascalCase')).toBe('pascal-case')
+	})
+
+	it('handles consecutive capitals (acronyms)', () => {
+		// Pins the actual behavior of the acronym branch in the regex.
+		expect(toKebabCase('getHTTPResponse')).toBe('get-http-response')
+	})
+
+	it('splits trailing digits with the preceding word', () => {
+		expect(toKebabCase('item1')).toBe('item1')
+		expect(toKebabCase('itemNumber2')).toBe('item-number2')
+	})
+
+	it('leaves an already-kebab string intact', () => {
+		expect(toKebabCase('already-kebab')).toBe('already-kebab')
+	})
+
+	it('returns the original string when there is nothing to match', () => {
+		expect(toKebabCase('!!!')).toBe('!!!')
+		expect(toKebabCase('')).toBe('')
+	})
+
+	it('handles a single character', () => {
+		expect(toKebabCase('a')).toBe('a')
+		expect(toKebabCase('A')).toBe('a')
+	})
+})

--- a/apps/www/src/utils/__test__/truncateString.test.ts
+++ b/apps/www/src/utils/__test__/truncateString.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { truncateString } from '../truncateString'
+
+describe('truncateString', () => {
+	it('returns the string unchanged when shorter than the limit', () => {
+		expect(truncateString('hello', 10)).toBe('hello')
+	})
+
+	it('truncates and appends an ellipsis when longer than the limit', () => {
+		expect(truncateString('hello world', 5)).toBe('hello...')
+	})
+
+	it('truncates at the boundary because the comparison is strictly less-than', () => {
+		// length === chars falls through to the else branch.
+		expect(truncateString('hello', 5)).toBe('hello...')
+	})
+
+	it('handles an empty string', () => {
+		expect(truncateString('', 5)).toBe('')
+	})
+
+	it('handles a zero-length limit', () => {
+		expect(truncateString('abc', 0)).toBe('...')
+	})
+})

--- a/apps/www/src/utils/link-resolver.ts
+++ b/apps/www/src/utils/link-resolver.ts
@@ -19,8 +19,6 @@ const linkResolver = (url: string, category: string) => {
 			return `/podcasts/${url}`
 		case 'resource':
 			return `/resources/${url}`
-		case 'category':
-			return `/categories/${url}`
 		case 'landingPage':
 			return `/p/${url}`
 		case 'handbook':

--- a/apps/www/src/utils/metaHelpers.ts
+++ b/apps/www/src/utils/metaHelpers.ts
@@ -1,9 +1,9 @@
-const getOgTitle = (title) => {
+const getOgTitle = (title: string) => {
 	return title + ' ♪ Downbeat Academy'
 }
 
-const limitDescription = (description) => {
-	description > 200 ? description.substring(0, 200) : description
+const limitDescription = (description: string) => {
+	return description.length > 200 ? description.substring(0, 200) : description
 }
 
 export { getOgTitle, limitDescription }

--- a/apps/www/tsconfig.json
+++ b/apps/www/tsconfig.json
@@ -33,6 +33,12 @@
 		],
 		"lib": ["dom", "dom.iterable", "esnext"]
 	},
-	"exclude": ["node_modules", "cypress/**/*"],
+	"exclude": [
+		"node_modules",
+		"cypress/**/*",
+		"src/**/__test__/**",
+		"vitest.config.ts",
+		"setup-tests.ts"
+	],
 	"include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx", "!cypress/**/*"]
 }

--- a/apps/www/tsconfig.test.json
+++ b/apps/www/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"types": ["vitest/globals", "@testing-library/jest-dom"]
+	},
+	"include": ["src/**/*", "vitest.config.ts", "setup-tests.ts"],
+	"exclude": ["node_modules", "cypress/**/*"]
+}

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -1,0 +1,47 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+	// `tsconfigPaths` resolves every path alias (`@/*`, `@lib/*`, `@utils/*`,
+	// `@actions/*`, …) so tests can import source the same way the app does,
+	// without hand-maintaining `resolve.alias`. It reads `tsconfig.test.json`,
+	// which includes the `__test__` dirs the production `tsconfig.json` excludes
+	// (so test files stay out of `next build` but still resolve aliases here).
+	plugins: [react(), tsconfigPaths({ projects: ['tsconfig.test.json'] })],
+	test: {
+		globals: true,
+		environment: 'jsdom',
+		setupFiles: './setup-tests.ts',
+		// Unit/integration tests live in `__test__` dirs next to the source they cover.
+		// Cypress E2E specs (cypress/**) are intentionally excluded.
+		include: ['src/**/__test__/**/*.test.{ts,tsx}'],
+		exclude: ['node_modules', '.next', 'cypress'],
+		// Source styling is irrelevant to logic tests; skip CSS module processing.
+		css: false,
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'html', 'lcov'],
+			reportsDirectory: './coverage',
+			// Scope coverage to the logic surface this suite targets so untested
+			// view/layout code doesn't distort the numbers.
+			include: [
+				'src/utils/**',
+				'src/lib/types/**',
+				// Only the pure calculator is in scope here; the sibling render
+				// component (reading-length.tsx) is covered by E2E tests.
+				'src/components/reading-length/calculateReadingLength.ts',
+				'src/components/music-notation/transfomers/**',
+				'src/actions/**',
+			],
+			thresholds: {
+				lines: 80,
+				functions: 80,
+				statements: 80,
+				branches: 75,
+			},
+		},
+	},
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,7 +192,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.7.0)(vite@8.0.12)
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@8.0.12)
 
   apps/cms-sanity:
     dependencies:
@@ -292,7 +292,7 @@ importers:
         version: link:../../packages/auth-permissions
       better-auth:
         specifier: ^1.6.10
-        version: 1.6.10(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2)(next@16.2.6)(pg@8.20.0)(react-dom@19.2.6)(react@19.2.6)
+        version: 1.6.10(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2)(next@16.2.6)(pg@8.20.0)(react-dom@19.2.6)(react@19.2.6)(vitest@4.1.6)
       boring-avatars:
         specifier: ^2.0.4
         version: 2.0.4(react-dom@19.2.6)(react@19.2.6)
@@ -375,6 +375,15 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.2.6)(react@19.2.6)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25.6.2
         version: 25.7.0
@@ -387,6 +396,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.12)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.6
+        version: 4.1.8(vitest@4.1.6)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -402,6 +417,9 @@ importers:
       ignore-loader:
         specifier: ^0.1.2
         version: 0.1.2
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       nanoid:
         specifier: ^5.1.11
         version: 5.1.11
@@ -417,6 +435,15 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vite:
+        specifier: ^8.0.12
+        version: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
+      vite-tsconfig-paths:
+        specifier: ^6.1.1
+        version: 6.1.1(typescript@5.9.3)(vite@8.0.12)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@8.0.12)
 
   packages/auth-permissions:
     dependencies:
@@ -608,10 +635,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.12
-        version: 8.0.12(sass@1.99.0)
+        version: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.0(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.12)
+        version: 5.0.0(typescript@5.9.3)(vite@8.0.12)
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(vite@8.0.12)
@@ -657,13 +684,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.12
-        version: 8.0.12(sass@1.99.0)
+        version: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
       vite-plugin-css-injected-by-js:
         specifier: ^5.0.1
         version: 5.0.1(vite@8.0.12)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.0(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.12)
+        version: 5.0.0(typescript@5.9.3)(vite@8.0.12)
       vite-plugin-svgr:
         specifier: ^5.2.0
         version: 5.2.0(typescript@5.9.3)(vite@8.0.12)
@@ -814,7 +841,6 @@ packages:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
-    dev: false
 
   /@asamuzakjp/css-color@5.1.11:
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -2111,6 +2137,10 @@ packages:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  /@bcoe/v8-coverage@1.0.2:
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   /@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5)(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1):
     resolution: {integrity: sha512-13h/rfSGMLl7zwyOb1BSlxAQZs2nQqn/xFI/bxB7zQuS95hVgTmNbKqhHtJYkNDtuJCcjEf1sNtLBHkvaPT/vw==}
@@ -5703,7 +5733,6 @@ packages:
   /@opentelemetry/api@1.9.1:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
-    dev: false
 
   /@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1):
     resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
@@ -9170,6 +9199,22 @@ packages:
       - webpack
     dev: true
 
+  /@storybook/builder-vite@10.3.6(storybook@10.3.6)(vite@8.0.12):
+    resolution: {integrity: sha512-gpvR/sE4BcrFtmQZ+Ker7zD23oQzoVeqD9nF6cK6yzY+Q0svJXyX2EPmFG4y+EwygD5/vNzDpP84gGMut8VRwg==}
+    peerDependencies:
+      storybook: ^10.3.6
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@storybook/csf-plugin': 10.3.6(storybook@10.3.6)(vite@8.0.12)
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      ts-dedent: 2.2.0
+      vite: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+    dev: true
+
   /@storybook/csf-plugin@10.3.6(rollup@4.60.3)(storybook@10.3.6)(vite@8.0.12):
     resolution: {integrity: sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==}
     peerDependencies:
@@ -9192,6 +9237,29 @@ packages:
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       unplugin: 2.3.11
       vite: 8.0.12(sass@1.99.0)
+    dev: true
+
+  /@storybook/csf-plugin@10.3.6(storybook@10.3.6)(vite@8.0.12):
+    resolution: {integrity: sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.3.6
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+    dependencies:
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      unplugin: 2.3.11
+      vite: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
     dev: true
 
   /@storybook/global@5.0.0:
@@ -9277,7 +9345,7 @@ packages:
     peerDependencies:
       storybook: ^10.3.6
     dependencies:
-      '@storybook/builder-vite': 10.3.6(rollup@4.60.3)(storybook@10.3.6)(vite@8.0.12)
+      '@storybook/builder-vite': 10.3.6(storybook@10.3.6)(vite@8.0.12)
       '@storybook/web-components': 10.3.6(lit@3.3.2)(storybook@10.3.6)
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
     transitivePeerDependencies:
@@ -10416,8 +10484,29 @@ packages:
         optional: true
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.12(sass@1.99.0)
+      vite: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
     dev: true
+
+  /@vitest/coverage-v8@4.1.8(vitest@4.1.6):
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@8.0.12)
 
   /@vitest/expect@3.2.4:
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -10468,7 +10557,7 @@ packages:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 8.0.12(@types/node@25.7.0)
+      vite: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
 
   /@vitest/pretty-format@3.2.4:
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
@@ -10477,6 +10566,11 @@ packages:
 
   /@vitest/pretty-format@4.1.6:
     resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  /@vitest/pretty-format@4.1.8:
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
     dependencies:
       tinyrainbow: 3.1.0
 
@@ -10527,6 +10621,13 @@ packages:
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
     dependencies:
       '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  /@vitest/utils@4.1.8:
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -10858,7 +10959,6 @@ packages:
   /agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
-    dev: false
 
   /ajv-formats@2.1.1(ajv@8.20.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -11144,6 +11244,13 @@ packages:
       tslib: 2.8.1
     dev: true
 
+  /ast-v8-to-istanbul@1.0.3:
+    resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   /astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -11394,7 +11501,7 @@ packages:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
     dev: false
 
-  /better-auth@1.6.10(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2)(next@16.2.6)(pg@8.20.0)(react-dom@19.2.6)(react@19.2.6):
+  /better-auth@1.6.10(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2)(next@16.2.6)(pg@8.20.0)(react-dom@19.2.6)(react@19.2.6)(vitest@4.1.6):
     resolution: {integrity: sha512-gzYaywJuhAkv9bTuFj1k6zaSKEAcabxAzYsBj0kXSMaQJVE9uS/qp2592IZmuvtMHO1ohLOP92jDPV6xVsZSoQ==}
     peerDependencies:
       '@lynx-js/react': '*'
@@ -11478,6 +11585,7 @@ packages:
       pg: 8.20.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@8.0.12)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -11568,7 +11676,7 @@ packages:
       pg: 8.20.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      vitest: 4.1.6(@types/node@25.7.0)(vite@8.0.12)
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@8.0.12)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -12695,7 +12803,6 @@ packages:
     dependencies:
       '@asamuzakjp/css-color': 3.1.7
       rrweb-cssom: 0.8.0
-    dev: false
 
   /cssstyle@6.2.0:
     resolution: {integrity: sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==}
@@ -12794,7 +12901,6 @@ packages:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-    dev: false
 
   /data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -12905,7 +13011,6 @@ packages:
 
   /decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
-    dev: false
 
   /decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
@@ -13397,7 +13502,6 @@ packages:
   /entities@6.0.0:
     resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
     engines: {node: '>=0.12'}
-    dev: false
 
   /entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
@@ -14927,7 +15031,6 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       whatwg-encoding: 3.1.1
-    dev: false
 
   /html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -15015,7 +15118,6 @@ packages:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /http-signature@1.4.0:
     resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
@@ -15044,7 +15146,6 @@ packages:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /human-id@4.1.1:
     resolution: {integrity: sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg==}
@@ -15558,7 +15659,6 @@ packages:
 
   /is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-    dev: false
 
   /is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -15743,7 +15843,6 @@ packages:
   /istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
-    dev: true
 
   /istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
@@ -15752,7 +15851,6 @@ packages:
       istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
-    dev: true
 
   /istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
@@ -15760,7 +15858,6 @@ packages:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-    dev: true
 
   /iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
@@ -15818,6 +15915,9 @@ packages:
   /jose@6.2.1:
     resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
     dev: false
+
+  /js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -15884,7 +15984,6 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: false
 
   /jsdom@28.1.0:
     resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
@@ -16544,7 +16643,6 @@ packages:
 
   /lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-    dev: false
 
   /lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
@@ -16570,6 +16668,13 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  /magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
   /make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
@@ -16582,7 +16687,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       semver: 7.8.0
-    dev: true
 
   /map-stream@0.1.0:
     resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
@@ -17182,7 +17286,6 @@ packages:
 
   /nwsapi@2.2.20:
     resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
-    dev: false
 
   /nypm@0.6.6:
     resolution: {integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==}
@@ -17590,7 +17693,6 @@ packages:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
     dependencies:
       entities: 6.0.0
-    dev: false
 
   /parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -19717,7 +19819,6 @@ packages:
 
   /rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
-    dev: false
 
   /run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
@@ -20190,7 +20291,6 @@ packages:
     engines: {node: '>=v12.22.7'}
     dependencies:
       xmlchars: 2.2.0
-    dev: false
 
   /scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -21112,7 +21212,6 @@ packages:
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-    dev: false
 
   /systeminformation@5.31.6:
     resolution: {integrity: sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==}
@@ -21432,7 +21531,6 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       punycode: 2.3.1
-    dev: false
 
   /tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -21876,6 +21974,50 @@ packages:
       - supports-color
     dev: true
 
+  /unplugin-dts@1.0.0(typescript@5.9.3)(vite@8.0.12):
+    resolution: {integrity: sha512-qz+U1lCscwq+t8Mkaxy5Esa7IQ5wWV18b4mnioOXSdnPaNiJ0+qgE3I+KL6UkXYZWxxGo2qdGone8LEQ52Sfkw==}
+    peerDependencies:
+      '@microsoft/api-extractor': '>=7'
+      '@rspack/core': ^1
+      '@vue/language-core': ~3.1.5
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '>=3'
+      typescript: '>=4'
+      vite: '>=3'
+      webpack: ^4 || ^5
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@rspack/core':
+        optional: true
+      '@vue/language-core':
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
+      '@volar/typescript': 2.4.28
+      compare-versions: 6.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+      kolorist: 1.8.0
+      local-pkg: 1.1.1
+      magic-string: 0.30.21
+      typescript: 5.9.3
+      unplugin: 2.3.11
+      vite: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
@@ -22157,7 +22299,7 @@ packages:
     peerDependencies:
       vite: '>8.0.0-0'
     dependencies:
-      vite: 8.0.12(sass@1.99.0)
+      vite: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
     dev: true
 
   /vite-plugin-dts@5.0.0(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.12):
@@ -22187,6 +22329,32 @@ packages:
       - webpack
     dev: true
 
+  /vite-plugin-dts@5.0.0(typescript@5.9.3)(vite@8.0.12):
+    resolution: {integrity: sha512-VLNAUttBq7pLxxL/m/ztjd5zj5yiviiC7ijfPFVLK5c45FLcibvieBsdjSka3a4ag1qdrAF9K3OysH4/lW+rPQ==}
+    peerDependencies:
+      '@microsoft/api-extractor': '>=7'
+      rollup: '>=3'
+      vite: '>=3'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      unplugin-dts: 1.0.0(typescript@5.9.3)(vite@8.0.12)
+      vite: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@vue/language-core'
+      - esbuild
+      - rolldown
+      - supports-color
+      - typescript
+      - webpack
+    dev: true
+
   /vite-plugin-svgr@5.2.0(typescript@5.9.3)(vite@8.0.12):
     resolution: {integrity: sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ==}
     peerDependencies:
@@ -22195,7 +22363,7 @@ packages:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
-      vite: 8.0.12(sass@1.99.0)
+      vite: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -22224,7 +22392,7 @@ packages:
       debug: 4.4.3(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.9.3)
-      vite: 8.0.12(sass@1.99.0)
+      vite: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -22283,7 +22451,7 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vite@8.0.12(@types/node@25.7.0):
+  /vite@8.0.12(@types/node@25.7.0)(tsx@4.21.0):
     resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
@@ -22332,6 +22500,7 @@ packages:
       postcss: 8.5.14
       rolldown: 1.0.0
       tinyglobby: 0.2.16
+      tsx: 4.21.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -22453,7 +22622,7 @@ packages:
       - tsx
       - yaml
 
-  /vitest@4.1.6(@types/node@25.7.0)(vite@8.0.12):
+  /vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@8.0.12):
     resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
@@ -22494,7 +22663,9 @@ packages:
       jsdom:
         optional: true
     dependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.7.0
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.6)
       '@vitest/expect': 4.1.6
       '@vitest/mocker': 4.1.6(vite@8.0.12)
       '@vitest/pretty-format': 4.1.6
@@ -22504,6 +22675,7 @@ packages:
       '@vitest/utils': 4.1.6
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
+      jsdom: 26.1.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
@@ -22513,7 +22685,7 @@ packages:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.12(@types/node@25.7.0)
+      vite: 8.0.12(@types/node@25.7.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - msw
@@ -22601,7 +22773,6 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       xml-name-validator: 5.0.0
-    dev: false
 
   /wait-on@9.0.4(debug@4.4.3):
     resolution: {integrity: sha512-k8qrgfwrPVJXTeFY8tl6BxVHiclK11u72DVKhpybHfUL/K6KM4bdyK9EhIVYGytB5MJe/3lq4Tf0hrjM+pvJZQ==}
@@ -22636,7 +22807,6 @@ packages:
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
-    dev: false
 
   /webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -22730,12 +22900,10 @@ packages:
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
     dependencies:
       iconv-lite: 0.6.3
-    dev: false
 
   /whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
-    dev: false
 
   /whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -22748,7 +22916,6 @@ packages:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
-    dev: false
 
   /whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
@@ -22971,11 +23138,9 @@ packages:
   /xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
-    dev: false
 
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-    dev: false
 
   /xstate@5.31.1:
     resolution: {integrity: sha512-3P7t7GQ61BvLu+8Cj6Zq7rcS34vecL9pvfN2ucUWmIFIUG+rAREviOs4Xy4OO3BuJHSz6RLU8eqDXxSbVotjDQ==}

--- a/turbo.json
+++ b/turbo.json
@@ -7,8 +7,8 @@
 			"inputs": ["$TURBO_DEFAULT$", ".env", ".env.local"]
 		},
 		"test": {
-			"dependsOn": ["build"],
-			"outputs": []
+			"dependsOn": ["^build"],
+			"outputs": ["coverage/**"]
 		},
 		"lint": {
 			"outputs": []


### PR DESCRIPTION
Stand up a Vitest 4 + Testing Library suite for apps/www (which previously had
only Cypress E2E coverage), matching the cadence-core/cadence-icons convention.
Covers pure utilities, Zod form schemas, the reading-length calculator, the
music-notation transformers, and the server actions (auth, email, profile) with
fully mocked dependencies (153 tests).

Wire it into Turbo and add a merge-blocking "Unit Tests" job to ci-www.yml that
runs coverage without a database or browser. A dedicated tsconfig.test.json keeps
test files resolving path aliases while excluding them from `next build`.

Fix bugs surfaced by the tests:
- limitDescription() returned undefined for every input; now returns its result
  and compares string length
- transformAccidental() had a "share" typo (now "sharp") and a return-less
  default (now returns null)
- linkResolver() had a duplicate, unreachable category case
- update-password schema mapped its mismatch error to a non-existent field