### PR TITLE
fix(admin): resolve N+1 connections and subscriber cache hazard

### DIFF
--- a/.changeset/fix-admin-connection-churn.md
+++ b/.changeset/fix-admin-connection-churn.md
@@ -1,0 +1,25 @@
+---
+"www": patch
+---
+
+Fix the two Sentry issues raised by the admin dashboard work: connection churn on `/admin` and a subscriber cache shape hazard.
+
+`DOWNBEATACADEMY-4E` was filed as an N+1 query, but there is no per-row loop — `/admin` issues nine distinct queries and the repeated span is the connection acquire, one per query. The cost came from those acquires missing a warm pool: in production `/admin` averaged 30ms per `pg-pool.connect` while `GET /api/auth/[...all]` on the same pool averaged 0.23ms.
+
+- `lib/db/drizzle.ts` passed a connection string straight to `drizzle()`, which builds a `pg.Pool` with zero options and so inherited pg's 30s idle timeout. Connections were dropped between page views and the next render paid a fresh TCP+TLS+auth handshake per query. The pools are now built explicitly with a 60s idle timeout, a 10s connection timeout, and `keepAlive`.
+- There was also no `globalThis` guard, so dev HMR leaked a new pool on every edit and connections were never warm locally — the reason development connects averaged 180–260ms against the remote database versus 30ms in production. Guarded following the pattern already used in `cadence-links`.
+- better-auth shares `authDb`, so session lookups get the warm pool too — a win on every authenticated route, not just `/admin`.
+- The four scalar counts (`countUsers`, `countUsersSince` ×2, `activeSessionCount`) collapse into a single `dashboardStats()` round trip. Because the page fans them out through `Promise.all`, four separate queries meant four *concurrent* acquires against an empty pool, which is what forced new physical connections. `/admin` drops from ~9 queries to ~6.
+- `requireAdmin` / `requireAuth` are wrapped in React `cache()`. `/admin/users` guards in both the admin layout and the page itself, and each call was a full better-auth session lookup.
+
+`DOWNBEATACADEMY-4F` (`subscribers.filter is not a function`) was already fixed, but the change that fixed it altered `listSubscribers` from returning `Subscriber[]` to `{ subscribers, error }` without changing its `unstable_cache` key. Two versions reading the same persistent cache therefore collide in both directions: old code on a new-shape entry throws exactly the reported error, and new code on an old-shape entry destructures an array into `undefined` and throws instead.
+
+- The cache key is now versioned, which is what makes a rollback safe.
+- A shared `readCache()` narrows the entry with `Array.isArray` before use, so an unexpected shape degrades into the existing error banner rather than throwing. `countSubscribers` goes through it too — it runs on the overview page, so an unguarded throw there took down the whole dashboard and not just `/admin/subscribers`.
+- `usersOverTime` gets the same versioned-key treatment. `MetricPoint` is JSON-native so a stale entry is harmless today, but the hazard is identical if its shape ever changes.
+
+Sentry SDK configuration, which is why both issues were raised from localhost in the first place:
+
+- `sentry.edge.config.ts` existed but nothing imported it, so edge-runtime errors went unreported. `instrumentation.ts` now uses the canonical `register()` runtime split and the server init moves to `sentry.server.config.ts`.
+- Neither server config set `environment` — only `instrumentation-client.ts` did. Both set it now.
+- `tracesSampleRate` drops to 0.1 outside production. Sampling every local request burns quota and distorts triage: a dev machine reaches the database over the internet, so its spans run roughly an order of magnitude slower than production and trip detectors production would not.

--- a/apps/www/instrumentation.ts
+++ b/apps/www/instrumentation.ts
@@ -1,18 +1,15 @@
 import * as Sentry from '@sentry/nextjs'
 
-export function register() {
-  Sentry.init({
-    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+// Load the per-runtime config rather than initialising inline. sentry.edge.config.ts
+// existed but nothing imported it, so edge-runtime errors went unreported.
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./sentry.server.config')
+  }
 
-    // Adjust this value in production, or use tracesSampler for greater control
-    tracesSampleRate: 1,
-
-    // Setting this option to true will print useful information to the console while you're setting up Sentry.
-    debug: false,
-
-    // uncomment the line below to enable Spotlight (https://spotlightjs.com)
-    // spotlight: process.env.NODE_ENV === 'development',
-  })
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    await import('./sentry.edge.config')
+  }
 }
 
 // Messages that represent expected infrastructure behaviour, not application bugs.

--- a/apps/www/sentry.edge.config.ts
+++ b/apps/www/sentry.edge.config.ts
@@ -8,8 +8,12 @@ import * as Sentry from '@sentry/nextjs'
 Sentry.init({
 	dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-	// Adjust this value in production, or use tracesSampler for greater control
-	tracesSampleRate: 1,
+	// Mirrors instrumentation-client.ts and sentry.server.config.ts.
+	environment: process.env.PROJECT_ENVIRONMENT ?? process.env.NODE_ENV,
+
+	// See sentry.server.config.ts — local traffic is sampled down so it doesn't
+	// dominate the quota or distort performance triage.
+	tracesSampleRate: process.env.NODE_ENV === 'production' ? 1 : 0.1,
 
 	// Setting this option to true will print useful information to the console while you're setting up Sentry.
 	debug: false,

--- a/apps/www/sentry.server.config.ts
+++ b/apps/www/sentry.server.config.ts
@@ -1,0 +1,27 @@
+// This file configures the initialization of Sentry on the Node.js server runtime.
+// It is loaded by `register()` in instrumentation.ts.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+import * as Sentry from '@sentry/nextjs'
+
+const isProduction = process.env.NODE_ENV === 'production'
+
+Sentry.init({
+	dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+
+	// Without this the server SDK guesses, so local runs get filed alongside real
+	// traffic. Mirrors instrumentation-client.ts.
+	environment: process.env.PROJECT_ENVIRONMENT ?? process.env.NODE_ENV,
+
+	// Sampling every local request both burns quota and distorts performance triage:
+	// a dev machine talks to the remote database over the internet, so its spans run
+	// roughly an order of magnitude slower than production and trip detectors that
+	// production would not.
+	tracesSampleRate: isProduction ? 1 : 0.1,
+
+	// Setting this option to true will print useful information to the console while you're setting up Sentry.
+	debug: false,
+
+	// uncomment the line below to enable Spotlight (https://spotlightjs.com)
+	// spotlight: process.env.NODE_ENV === 'development',
+})

--- a/apps/www/src/app/admin/page.tsx
+++ b/apps/www/src/app/admin/page.tsx
@@ -5,9 +5,7 @@ import { ChartCard } from './_components/chart-card'
 import { UsersOverTimeChart } from './_components/charts/users-over-time-chart'
 import { ProviderBreakdownChart } from './_components/charts/provider-breakdown-chart'
 import {
-	countUsers,
-	countUsersSince,
-	activeSessionCount,
+	dashboardStats,
 	recentUsers,
 	recentSessions,
 	countSubscribers,
@@ -16,39 +14,22 @@ import {
 } from '@/lib/admin/queries'
 import { formatRelativeTime, truncate } from '@/lib/admin/format'
 
-function daysAgo(days: number): Date {
-	const d = new Date()
-	d.setDate(d.getDate() - days)
-	return d
-}
+const RECENT_WINDOW_DAYS = 7
+const EXTENDED_WINDOW_DAYS = 30
 
 export default async function AdminOverviewPage() {
-	const sevenDaysAgo = daysAgo(7)
-	const thirtyDaysAgo = daysAgo(30)
+	const [stats, subscriberCount, latestUsers, latestSessions, signupTimeline, providers] =
+		await Promise.all([
+			dashboardStats(RECENT_WINDOW_DAYS, EXTENDED_WINDOW_DAYS),
+			countSubscribers(),
+			recentUsers(10),
+			recentSessions(10),
+			usersOverTime(90),
+			authProviderBreakdown(),
+		])
 
-	const [
-		totalUsers,
-		usersLast7d,
-		usersLast30d,
-		activeSessions,
-		subscriberCount,
-		latestUsers,
-		latestSessions,
-		signupTimeline,
-		providers,
-	] = await Promise.all([
-		countUsers(),
-		countUsersSince(sevenDaysAgo),
-		countUsersSince(thirtyDaysAgo),
-		activeSessionCount(),
-		countSubscribers(),
-		recentUsers(10),
-		recentSessions(10),
-		usersOverTime(90),
-		authProviderBreakdown(),
-	])
-
-	const monthlyDelta = usersLast30d
+	const { totalUsers, newUsersRecent, newUsersExtended, activeSessions } = stats
+	const monthlyDelta = newUsersExtended
 
 	return (
 		<Flex direction="column" gap="x-large">
@@ -66,14 +47,14 @@ export default async function AdminOverviewPage() {
 							: {
 									value: monthlyDelta,
 									direction: monthlyDelta > 0 ? 'up' : 'down',
-									label: 'in 30d',
+									label: `in ${EXTENDED_WINDOW_DAYS}d`,
 								}
 					}
 				/>
 				<MetricCard
-					label="New users (7d)"
-					value={usersLast7d}
-					hint={`${usersLast30d} in last 30d`}
+					label={`New users (${RECENT_WINDOW_DAYS}d)`}
+					value={newUsersRecent}
+					hint={`${newUsersExtended} in last ${EXTENDED_WINDOW_DAYS}d`}
 				/>
 				<MetricCard
 					label="Active sessions"

--- a/apps/www/src/lib/admin/queries/sessions.ts
+++ b/apps/www/src/lib/admin/queries/sessions.ts
@@ -1,17 +1,12 @@
 import 'server-only'
 import { cache } from 'react'
-import { count, desc, eq, gt, sql } from 'drizzle-orm'
+import { desc, eq } from 'drizzle-orm'
 import { authDb } from '@/lib/db/drizzle'
 import { session, user } from '@/lib/db/schema/auth'
 import type { RecentSession } from '../types'
 
-export const activeSessionCount = cache(async (): Promise<number> => {
-	const [row] = await authDb
-		.select({ value: count() })
-		.from(session)
-		.where(gt(session.expiresAt, sql`now()`))
-	return row?.value ?? 0
-})
+// The active-session count lives in `dashboardStats` (./users), folded into the same
+// round trip as the user counts so the overview page doesn't spend a connection on it.
 
 export const recentSessions = cache(async (limit = 10): Promise<RecentSession[]> => {
 	const rows = await authDb

--- a/apps/www/src/lib/admin/queries/subscribers.ts
+++ b/apps/www/src/lib/admin/queries/subscribers.ts
@@ -72,10 +72,28 @@ async function fetchSubscribersRaw(): Promise<CachedSubscribers> {
 	return { subscribers, error: null }
 }
 
-const cachedFetch = unstable_cache(fetchSubscribersRaw, ['admin', 'subscribers'], {
+// The version suffix is part of the contract: this function's return shape changed once
+// already (from `Subscriber[]` to `{ subscribers, error }`) without the key changing,
+// which lets two deployments read each other's incompatible entries. Bump the suffix
+// whenever `CachedSubscribers` changes shape.
+const cachedFetch = unstable_cache(fetchSubscribersRaw, ['admin', 'subscribers', 'v2'], {
 	tags: [SUBSCRIBERS_TAG],
 	revalidate: 600,
 })
+
+/**
+ * A cache entry written by a different version of this module can be any shape at all,
+ * so narrow before trusting it. Returning the `error` envelope rather than throwing
+ * keeps a bad entry contained: the subscribers page renders its error banner, and the
+ * admin overview — which calls `countSubscribers` — still renders.
+ */
+async function readCache(): Promise<CachedSubscribers> {
+	const cached = await cachedFetch()
+	if (!cached || !Array.isArray(cached.subscribers)) {
+		return { subscribers: [], error: 'Subscriber cache returned an unexpected shape.' }
+	}
+	return { subscribers: cached.subscribers, error: cached.error ?? null }
+}
 
 function hydrate(record: SubscriberRecord): Subscriber {
 	return {
@@ -85,11 +103,11 @@ function hydrate(record: SubscriberRecord): Subscriber {
 }
 
 export const listSubscribers = cache(async (): Promise<SubscribersResult> => {
-	const { subscribers, error } = await cachedFetch()
+	const { subscribers, error } = await readCache()
 	return { subscribers: subscribers.map(hydrate), error }
 })
 
 export const countSubscribers = cache(async (): Promise<number> => {
-	const { subscribers } = await cachedFetch()
+	const { subscribers } = await readCache()
 	return subscribers.filter((s) => !s.unsubscribed).length
 })

--- a/apps/www/src/lib/admin/queries/users.ts
+++ b/apps/www/src/lib/admin/queries/users.ts
@@ -27,18 +27,53 @@ export type ListUsersResult = {
 }
 
 
-export const countUsers = cache(async (): Promise<number> => {
-	const [row] = await authDb.select({ value: count() }).from(user)
-	return row?.value ?? 0
-})
+export type DashboardStats = {
+	totalUsers: number
+	newUsersRecent: number
+	newUsersExtended: number
+	activeSessions: number
+}
 
-export const countUsersSince = cache(async (since: Date): Promise<number> => {
-	const [row] = await authDb
-		.select({ value: count() })
-		.from(user)
-		.where(gte(user.createdAt, since))
-	return row?.value ?? 0
-})
+/**
+ * The overview cards need four independent scalars. Issued as separate queries they
+ * cost four pool connections per render — and because the page fans them out through
+ * `Promise.all`, four *concurrent* ones, which forces the pool to open new physical
+ * connections. As scalar subqueries they cost a single round trip.
+ *
+ * `count(*)` is bigint, which node-postgres hands back as a string, so the `::int`
+ * casts are load-bearing: without them the metric cards render `"12"` and the delta
+ * arithmetic on the overview page concatenates instead of adding.
+ */
+export const dashboardStats = cache(
+	async (recentDays: number, extendedDays: number): Promise<DashboardStats> => {
+		const result = await authDb.execute<{
+			total_users: number
+			new_users_recent: number
+			new_users_extended: number
+			active_sessions: number
+		}>(sql`
+			select
+				(select count(*)::int from ${user}) as total_users,
+				(select count(*)::int from ${user}
+					where ${user.createdAt} >= now() - (${recentDays}::int * interval '1 day')
+				) as new_users_recent,
+				(select count(*)::int from ${user}
+					where ${user.createdAt} >= now() - (${extendedDays}::int * interval '1 day')
+				) as new_users_extended,
+				(select count(*)::int from ${session}
+					where ${session.expiresAt} > now()
+				) as active_sessions
+		`)
+
+		const row = result.rows[0]
+		return {
+			totalUsers: row?.total_users ?? 0,
+			newUsersRecent: row?.new_users_recent ?? 0,
+			newUsersExtended: row?.new_users_extended ?? 0,
+			activeSessions: row?.active_sessions ?? 0,
+		}
+	}
+)
 
 export const countByRole = cache(async (): Promise<Record<string, number>> => {
 	const rows = await authDb
@@ -163,8 +198,10 @@ async function fetchUsersOverTime(days: number): Promise<MetricPoint[]> {
 	return points
 }
 
+// Versioned key — see the note on `cachedFetch` in ./subscribers. `MetricPoint` is
+// JSON-native today, so a stale entry is harmless, but bump `v1` if its shape changes.
 export const usersOverTime = cache(
-	unstable_cache(fetchUsersOverTime, ['admin', 'users-over-time'], {
+	unstable_cache(fetchUsersOverTime, ['admin', 'users-over-time', 'v1'], {
 		tags: ['admin:users'],
 		revalidate: 60,
 	})

--- a/apps/www/src/lib/auth/require-auth.ts
+++ b/apps/www/src/lib/auth/require-auth.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import { redirect } from 'next/navigation'
 import { headers } from 'next/headers'
 import { auth } from './auth'
@@ -9,9 +10,13 @@ const guards = createGuards({
 	redirect,
 })
 
-export const requireAuth = guards.requireAuth
+// Each guard call is a full better-auth session lookup, and nested routes guard at more
+// than one level — `/admin/users` runs `requireAdmin('/admin')` in both the admin layout
+// and the page itself. Memoizing per request collapses those into one query. The path
+// argument is a plain string, so repeated calls with the same path share a cache entry.
+export const requireAuth = cache(guards.requireAuth)
 export const requireRole = guards.requireRole
-export const requireAdmin = guards.requireAdmin
+export const requireAdmin = cache(guards.requireAdmin)
 
 /**
  * Get the current session without requiring authentication.

--- a/apps/www/src/lib/db/drizzle.ts
+++ b/apps/www/src/lib/db/drizzle.ts
@@ -1,4 +1,38 @@
 import { drizzle } from 'drizzle-orm/node-postgres'
+import { Pool } from 'pg'
 
-export const authDb = drizzle(process.env.DATABASE_URL_AUTH)
-export const cmsDb = drizzle(process.env.DATABASE_URL_CMS)
+// Passing a connection string straight to `drizzle()` builds a `pg.Pool` with zero
+// options, so it inherits pg's defaults — notably `idleTimeoutMillis: 30000`, which
+// closes idle connections between page views. Pages that fan several queries out at
+// once (see `app/admin/page.tsx`) then pay a fresh TCP+TLS+auth handshake per query
+// on every render. Build the pools explicitly instead.
+function createPool(connectionString: string | undefined): Pool {
+	return new Pool({
+		connectionString,
+		max: 10,
+		// Outlive the gap between page views so repeat renders reuse warm connections.
+		idleTimeoutMillis: 60_000,
+		// Fail fast rather than hanging a render when the database is unreachable.
+		connectionTimeoutMillis: 10_000,
+		// Keep NAT/proxy layers between us and Railway from silently dropping idle sockets.
+		keepAlive: true,
+	})
+}
+
+// Without this, dev HMR re-evaluates the module on every edit and leaks a fresh pool
+// each time, so connections are never warm. Production evaluates the module once.
+const globalForDb = globalThis as unknown as {
+	authPool?: Pool
+	cmsPool?: Pool
+}
+
+const authPool = globalForDb.authPool ?? createPool(process.env.DATABASE_URL_AUTH)
+const cmsPool = globalForDb.cmsPool ?? createPool(process.env.DATABASE_URL_CMS)
+
+if (process.env.NODE_ENV !== 'production') {
+	globalForDb.authPool = authPool
+	globalForDb.cmsPool = cmsPool
+}
+
+export const authDb = drizzle(authPool)
+export const cmsDb = drizzle(cmsPool)


### PR DESCRIPTION
Two Sentry issues landed from the admin dashboard work. The span data told a different story than the issue titles did, so the fixes are not quite where the reports pointed.

DOWNBEATACADEMY-4E is filed as an N+1 query, but there is no per-row loop — /admin issues nine distinct queries and the repeated span is the connection acquire, one per query. What makes it expensive is that those acquires are not hitting a warm pool. In production /admin averaged 30ms per pg-pool.connect while GET /api/auth/[...all] on the same pool averaged 0.23ms, so /admin was opening real connections rather than reusing idle ones.

DOWNBEATACADEMY-4F was already fixed by 279b5128, the commit immediately after the release it was reported on. What it left behind is the reason it could happen at all, addressed below.

database connections:

- lib/db/drizzle.ts passed a connection string straight to drizzle(), which builds a pg.Pool with zero options. That inherits pg's idleTimeoutMillis of 30s, so connections were dropped between page views and the next render paid a fresh TCP+TLS+auth handshake per query. The pools are now built explicitly with a 60s idle timeout, a 10s connection timeout and keepAlive, so repeat renders reuse warm connections.
- There was also no globalThis guard, so dev HMR re-evaluated the module on every edit and leaked a new pool each time — connections were never warm locally at all. This is why development connects averaged 180-260ms against the remote database versus 30ms in production, and why the detector fired on dev traffic. Guarded following the pattern already in apps/cadence-links.
- better-auth shares authDb, so session lookups get the warm pool too. That is a win on every authenticated route, not just /admin.

admin overview queries:

- The four scalar counts (countUsers, countUsersSince x2, activeSessionCount) are now one dashboardStats() round trip using scalar subqueries. Because the page fans them out through Promise.all, four separate queries meant four *concurrent* acquires against an empty pool — precisely the burst that forced new physical connections. /admin drops from ~9 queries to ~6.
- The ::int casts in that query are load-bearing: count(*) is bigint, which node-postgres returns as a string, so without them the metric cards would render "12" and the delta arithmetic would concatenate.
- requireAdmin/requireAuth are wrapped in React cache(). /admin/users guards in both the admin layout and the page itself, and each call was a full better-auth session lookup.
- The 7- and 30-day windows move into named constants and drive the card labels, so the copy cannot drift from the query.

subscribers cache:

- 279b5128 changed listSubscribers from returning Subscriber[] to { subscribers, error } but left the unstable_cache key unchanged. Two versions reading the same persistent cache therefore collide: old code on a new-shape entry throws exactly the reported "subscribers.filter is not a function", and new code on an old-shape entry destructures an array into undefined and throws in subscribers.ts instead. The key is now versioned, which is what makes a rollback safe in both directions.
- A shared readCache() narrows the entry with Array.isArray before use, so an unexpected shape degrades into the existing error banner rather than throwing. countSubscribers goes through it too — it runs on the overview page, so an unguarded throw there took down the whole dashboard and not just /admin/subscribers.
- usersOverTime gets the same versioned-key treatment. MetricPoint is JSON-native so a stale entry is harmless today, but the hazard is identical if its shape ever changes.

sentry configuration:

- sentry.edge.config.ts existed but nothing imported it, so edge-runtime errors went unreported. instrumentation.ts now uses the canonical register() runtime split and the server init moves to sentry.server.config.ts.
- Neither server config set `environment`, which only instrumentation-client.ts was doing. Both set it now.
- tracesSampleRate drops to 0.1 outside production. Sampling every local request burns quota and distorts triage: a dev machine reaches the database over the internet, so its spans run roughly an order of magnitude slower than production and trip detectors production would not. Both of these issues were raised entirely from localhost.

Verified: www builds, tsc is clean across src/, eslint is clean on the changed files, and the SQL drizzle generates for dashboardStats was rendered through the dialect to confirm identifier quoting and parameter binding. Not verified: the query has not been executed against a real database — there is no local Postgres here and the credentials are in Infisical — so loading /admin against real data is still worth doing before this ships. Worth confirming max: 10 against the Railway connection limit if other services share that instance.

Left alone as out of scope: cmsDb, countByRole, countBanned and countUnverified are all now dead code.

Fixes DOWNBEATACADEMY-4E
Fixes DOWNBEATACADEMY-4F