### PR TITLE
chore: PR, issue, and contribution scaffolding

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Every change is reviewed by the maintainer.
+# Explicit paths below are for clarity about which areas carry the most risk,
+# not because ownership differs — see docs/adr/0002-known-gaps.md.
+
+*                               @jorytindall
+
+# OAuth provider — a mistake here signs every user out of every app
+/apps/auth/                     @jorytindall
+/packages/auth-permissions/     @jorytindall
+
+# Design system — changes propagate to all three apps at once
+/packages/cadence-core/         @jorytindall
+/packages/cadence-tokens/       @jorytindall
+
+# Agent-facing contracts and CI
+/AGENTS.md                      @jorytindall
+/CLAUDE.md                      @jorytindall
+/.claude/                       @jorytindall
+/.github/                       @jorytindall
+/docs/                          @jorytindall

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,64 @@
+name: Bug
+description: Something is broken
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing: check [`docs/adr/0002-known-gaps.md`](../blob/main/docs/adr/0002-known-gaps.md).
+        Several things in this repo are broken on purpose and already recorded there.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happens
+      description: The actual behaviour, and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to …
+        2. Click …
+        3. Observe …
+    validations:
+      required: true
+
+  - type: dropdown
+    id: workspace
+    attributes:
+      label: Where
+      multiple: true
+      options:
+        - apps/www
+        - apps/auth
+        - apps/cadence-links
+        - apps/cms-sanity
+        - packages/cadence-core
+        - packages/cadence-tokens
+        - packages/cadence-icons
+        - packages/auth-permissions
+        - packages/email
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Production
+        - Local development
+        - Both
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Errors, logs, screenshots
+      description: Console output, a Sentry link, or a screenshot. Redact any secrets.

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,25 @@
+name: Chore
+description: Maintenance, dependencies, tooling, or technical debt
+labels: ['chore']
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs doing
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why now
+      description: What it unblocks, or what it costs to keep deferring.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: gaps
+    attributes:
+      label: Known gaps register
+      options:
+        - label: I have checked whether this is already recorded in docs/adr/0002-known-gaps.md

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,42 @@
+name: Feature
+description: Something new, or a change to how something works
+labels: ['feature']
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What is hard or impossible today, and for whom. Not the solution — the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you have in mind
+      description: Optional. A sketch of the solution, if you have one.
+
+  - type: dropdown
+    id: workspace
+    attributes:
+      label: Likely area
+      multiple: true
+      options:
+        - apps/www
+        - apps/auth
+        - apps/cadence-links
+        - apps/cms-sanity
+        - Cadence design system
+        - Content modelling
+        - Infrastructure
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: How we would know it works
+      description: What should be true when this is finished.
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,94 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+    # Grouped to match how these updates have been batched by hand
+    # (see the may-2026-dep-updates-group-a/b/c branches in the history).
+    # One PR per coherent area beats twenty single-package PRs for a solo maintainer.
+    groups:
+      next:
+        patterns:
+          - 'next'
+          - '@next/*'
+          - 'eslint-config-next'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+      sanity:
+        patterns:
+          - 'sanity'
+          - '@sanity/*'
+          - 'sanity-plugin-*'
+          - 'next-sanity'
+          - '@portabletext/*'
+      auth:
+        patterns:
+          - 'better-auth'
+          - '@better-auth/*'
+      database:
+        patterns:
+          - 'drizzle-orm'
+          - 'drizzle-kit'
+          - 'pg'
+          - '@types/pg'
+          - 'postgres'
+      radix:
+        patterns:
+          - '@radix-ui/*'
+      storybook:
+        patterns:
+          - 'storybook'
+          - '@storybook/*'
+          - 'chromatic'
+      testing:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
+          - 'cypress'
+          - 'cypress-axe'
+          - '@testing-library/*'
+          - 'jsdom'
+          - '@open-wc/testing'
+      build-tooling:
+        patterns:
+          - 'vite'
+          - 'vite-*'
+          - 'rollup'
+          - 'rollup-*'
+          - '@rollup/*'
+          - 'turbo'
+          - 'typescript'
+          - 'style-dictionary'
+      observability:
+        patterns:
+          - '@sentry/*'
+          - 'posthog-js'
+          - 'posthog-node'
+          - 'fathom-client'
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: chore
+    labels:
+      - dependencies
+    groups:
+      actions:
+        patterns:
+          - '*'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,25 +1,53 @@
-# Pull Request Description
+<!--
+Keep this short. The commit message carries the detail; this is for the reviewer.
+-->
 
-## What does this PR do?
-Brief description of your changes
+## What and why
 
-## Related Issues
-Fixes #[issue-number]
+<!-- One or two sentences. Lead with the problem, not the diff. -->
 
-## Type of Change
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation
+**Notion task:** <!-- link, or "n/a" -->
 
-## Testing
-Describe how you tested these changes
+## Affected workspaces
 
-## Checklist
-- [ ] I have tested my changes
-- [ ] I have updated documentation
-- [ ] I have added tests (if applicable)
-- [ ] All tests pass
+<!-- Tick what this touches. Package changes affect every consuming app. -->
 
-## Notes
-Any additional context or notes for reviewers
+- [ ] `apps/www`
+- [ ] `apps/auth` ⚠️ OAuth provider — affects sign-in for every app
+- [ ] `apps/cadence-links`
+- [ ] `apps/cms-sanity`
+- [ ] `packages/cadence-core`
+- [ ] `packages/cadence-tokens` ⚠️ requires rebuilding `cadence-core`
+- [ ] `packages/cadence-icons`
+- [ ] `packages/auth-permissions` ⚠️ lands in all three Next apps at once
+- [ ] `packages/email`
+- [ ] Other / docs only
+
+## Verification
+
+<!-- What you actually ran and looked at. Be specific; "tested locally" says nothing. -->
+
+- [ ] `pnpm verify` passes
+- [ ] Changeset added (or: docs-only, none needed)
+
+Beyond the gate:
+
+<!--
+Delete what does not apply.
+- Storybook: rendered the component, tabbed through it
+- App: ran `pnpm www:dev` and checked the page
+- Sanity: created a real document and confirmed it renders
+- Auth: walked sign-in AND sign-out across apps
+- DB: reviewed the `drizzle-kit push` diff
+-->
+
+## Screenshots
+
+<!-- Required for anything visual. Before/after if it is a change. -->
+
+## Notes for the reviewer
+
+<!--
+Anything deliberately left undone, a trade-off you made, or a part you are unsure
+about. If this is part of a stack, say what it is stacked on.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# Contributing
+
+How work moves through this repository. If you are an AI agent, read
+[`AGENTS.md`](./AGENTS.md) as well — it is the operational contract.
+
+## Setup
+
+```bash
+pnpm install            # pnpm 9, pinned via packageManager
+pnpm build:packages     # required — apps cannot resolve Cadence until it is built
+pnpm dev
+```
+
+Secrets come from Infisical; the dev scripts wrap Next in `infisical run`. Without
+Infisical access, use each app's `dev:ci` script and a manual `.env.local` (see the app's
+`docs/setup/`). Never commit `.env*`.
+
+## Branches
+
+Off `main`, prefixed by intent:
+
+| Prefix | For |
+| --- | --- |
+| `feat/` | New functionality |
+| `fix/` | Bug fixes |
+| `chore/` | Maintenance, dependencies, tooling |
+| `docs/` | Documentation |
+
+Kebab-case after the prefix: `feat/course-enrollment`, `fix/oauth-callback-state`.
+
+**Never commit directly to `main`.**
+
+## The verification gate
+
+Before opening a PR:
+
+```bash
+pnpm verify        # turbo run lint typecheck test — every workspace, ~10s warm
+```
+
+It must exit 0. If it hangs, a `test` script has regressed to bare `vitest` (watch mode)
+— fix that rather than working around it.
+
+`verify` is the floor, not the whole answer. It does not cover formatting (not yet gated),
+`cadence-core` linting (no setup), E2E, or anything visual. Depending on what you changed,
+also:
+
+| Changed | Also do |
+| --- | --- |
+| A `cadence-core` component | `pnpm core:storybook` — render it, tab through it |
+| Anything visual | Run the app and look at it |
+| A Sanity schema | `pnpm cms:dev`, create a real document, confirm `www` renders it |
+| Auth or sessions | Walk sign-in **and** sign-out across apps |
+| A design token | `pnpm tokens:build && pnpm build:packages` — tokens alone is not enough |
+| A DB schema | Review the `drizzle-kit push` diff; it can drop columns |
+
+## Changesets
+
+**Every change to a versioned package needs one.** Create `.changeset/<description>.md`:
+
+```md
+---
+'cadence-core': minor
+'www': patch
+---
+
+What changed and why. Lead with the problem.
+```
+
+`patch` for fixes, `minor` for features, `major` for breaking changes. Docs-only changes
+to `docs/` or `AGENTS.md` files do not need one.
+
+Merging to `main` opens a "Version Packages" PR that bumps versions and writes changelogs.
+Nothing is published to a registry — versioning exists for changelogs and coordination.
+
+## Commits
+
+Short imperative subject, then a body explaining **why**. Lead with the problem the change
+solves. Note anything deliberately left undone.
+
+## Pull requests
+
+Fill in the template honestly — particularly the verification section. "Tested locally"
+tells a reviewer nothing.
+
+### Stacked PRs
+
+When a change depends on unmerged work, stack it. GitHub's native stacked pull requests
+(public preview) are the default — install the extension once with
+`gh extension install github/gh-stack`:
+
+```bash
+gh stack init --base main          # start a stack
+gh stack add -m "feat: the thing"  # branch + commit on top
+gh stack submit                    # open/update the PRs and link them
+gh stack merge --squash            # land the whole stack atomically
+```
+
+Plain git still works, and a correctly-chained set of PRs gets adopted as a stack
+automatically — branch off the parent and target it:
+
+```bash
+git checkout feat/foundation
+git checkout -b feat/api
+gh pr create --base feat/foundation
+```
+
+Getting `--base` wrong makes the PR show every commit from the parent. Without a native
+stack, merge bottom-up, verifying each PR's base retargets after the one below merges.
+
+Branch protections apply against `main` for **every** PR in a stack, not against the
+branch below it — stacking never lowers the bar for what reaches `main`. See the `stack`
+skill in [`.claude/skills/`](./.claude/skills/).
+
+## Before you "fix" something
+
+Read [`docs/adr/0002-known-gaps.md`](./docs/adr/0002-known-gaps.md). Several things in
+this repo look broken and are — deliberately, with recorded reasons. Fixing one as a side
+effect of unrelated work makes both changes harder to review.
+
+If you close a gap, delete its entry in the same PR.
+
+## Conventions
+
+The full set is in [`AGENTS.md`](./AGENTS.md). The ones most often missed:
+
+- A new `cadence-core` component must be exported from `src/index.ts` — the component
+  **and** its `*Props` type. Otherwise it does not exist to consumers.
+- Every style value is a `--cds-*` token. Semantic colour tokens, never palette tokens.
+- **Productive** type for app chrome, **expressive** for editorial and brand. Never mixed
+  within one surface.
+- Prefer a `cadence-core` component over hand-rolled markup.
+- A Sanity object used in `richText` must be registered in
+  `apps/www/src/components/rich-text/components.tsx`, or it renders as nothing.
+
+## Documentation
+
+Each workspace has an `AGENTS.md`; architecture lives in [`docs/`](./docs/README.md).
+When a change makes documentation wrong, fix it in the same PR.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,12 @@ These documents explain *why* things are the way they are.
 | [`adr/0001-record-architecture-decisions.md`](./adr/0001-record-architecture-decisions.md) | Why this repo keeps ADRs, and the format |
 | [`adr/0002-known-gaps.md`](./adr/0002-known-gaps.md) | **The known-gaps register.** Read before "fixing" anything that looks broken |
 
+## Workflows
+
+| Document | Covers |
+| --- | --- |
+| [`workflows/sdlc.md`](./workflows/sdlc.md) | The development loop end to end — Notion task → plan → build → verify → ship → review → merge |
+
 ## Proposals
 
 [`proposals/`](./proposals/) holds design work that has not been decided on yet.

--- a/docs/workflows/sdlc.md
+++ b/docs/workflows/sdlc.md
@@ -1,0 +1,118 @@
+# The development loop
+
+How a piece of work travels from an idea in Notion to production, and where the tooling in
+this repo plugs in. This is what makes the `AGENTS.md` files, the `docs/` tree, the
+skills, and the agents legible as one system rather than six unrelated additions.
+
+```
+Notion task
+    │
+    ├─ /plan-feature ────── read the task, load the workspace AGENTS.md,
+    │                       check the gaps register, plan, branch,
+    │                       set Status → In Progress
+    │
+    ├─ build ────────────── with the domain agent for the area
+    │                       (cadence-design-system, sanity-content, auth-security, …)
+    │                       and /new-component or /new-sanity-type where they apply
+    │
+    ├─ /ship ────────────── pnpm verify, manual checks, changeset,
+    │                       commit, push, PR against the right base,
+    │                       write PR link back to Notion
+    │
+    ├─ review ───────────── code-reviewer agent, then CI
+    │
+    ├─ merge ────────────── changesets opens "Version Packages";
+    │                       Railway deploys from main
+    │
+    └─ Status → Completed
+```
+
+## 1. Plan
+
+Start from a Notion task where one exists — the roadmap is the backlog, and the parent
+epic usually carries the "why" that the task itself omits.
+
+`/plan-feature` does the mechanical part: fetches the task, works out which workspaces are
+involved, **reads their `AGENTS.md`**, checks
+[`docs/adr/0002-known-gaps.md`](../adr/0002-known-gaps.md), searches for what already
+exists, and creates a correctly-named branch.
+
+The step that pays for itself is reading the workspace contract *before* planning. Most
+wasted work in this repo has come from not knowing a local rule — that a component needs a
+barrel export, that a Sanity object needs registering in two places, that a token change
+needs two builds.
+
+**Check the gaps register.** Several things look broken and are, deliberately. Planning a
+fix for one as a side effect of unrelated work makes both harder to review.
+
+## 2. Build
+
+Work in dependency order: packages before apps, schema before query before route.
+
+Reach for the agent that owns the area — `cadence-design-system`, `sanity-content`,
+`auth-security`, `javascript-engineer`, `accessibility-engineer`, `test-engineer`.
+They carry the failure modes so you do not have to hold them in your head.
+
+Two skills cover the mechanical chains:
+
+- `/new-component` — the `cadence-core` scaffold, and the two rules that reliably bite
+- `/new-sanity-type` — the five-step chain across `cms-sanity` and `www`
+
+## 3. Verify
+
+```bash
+pnpm verify        # lint + typecheck + test, every workspace, ~10s warm
+```
+
+This is the floor. What it does **not** cover is in
+[`../../AGENTS.md`](../../AGENTS.md): formatting is not gated, `cadence-core` has no
+linting, E2E is separate, and nothing automated looks at the screen.
+
+So also: render it in Storybook, run the app, create a real Sanity document, walk the full
+sign-in *and* sign-out chain. Report what you actually ran — if a step was skipped, say
+which.
+
+## 4. Ship
+
+`/ship` runs the gate, adds the changeset with the right package list, commits, pushes,
+opens the PR against the correct base, and writes the PR link back to Notion.
+
+For stacked work, `/stack` handles branching off unmerged work, restacking after a parent
+changes, and merging bottom-up.
+
+## 5. Review
+
+The `code-reviewer` agent is read-only by design and checks the conventions this repo
+actually has — barrel exports, token usage, the type-family split, missing changesets,
+unregistered Portable Text types.
+
+CI (`ci-monorepo.yml`) runs lint, typecheck, and tests across every workspace.
+`ci-www-e2e.yml` runs Cypress, path-filtered.
+
+## 6. Merge and release
+
+Merging to `main` triggers `release.yml`, which opens a "Version Packages" PR. Merging
+*that* bumps versions and writes changelogs. Nothing is published to a registry —
+versioning exists for changelogs and coordination.
+
+Railway deploys from `main`. Note that **no deploy configuration lives in git** — build
+and start commands are set in the Railway dashboard.
+
+Then set the Notion task to `Completed`.
+
+## Where the automation is deliberately absent
+
+The loop is human-in-the-loop on purpose. Claude runs locally, with a person reviewing;
+**CI stays deterministic** — lint, typecheck, test, deploy, and nothing that writes code.
+
+That boundary is the point. The value is in agents having accurate context and a
+trustworthy verification gate, not in removing the reviewer. An agent that can merge its
+own work is only as good as the tests, and the tests here are honest about what they do
+not cover.
+
+## Related
+
+- [`../../AGENTS.md`](../../AGENTS.md) — the repo-wide contract
+- [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) — the same loop for humans
+- [`../../.claude/README.md`](../../.claude/README.md) — the skills and agents
+- [`../adr/0002-known-gaps.md`](../adr/0002-known-gaps.md) — what is deliberately unfinished


### PR DESCRIPTION
## What and why

The handoff surface between finished work and review. Completes the stack by making the loop legible to a reviewer — human or agent — rather than only to whoever wrote it.

**Notion task:** n/a · **Stacked on** #269

## Affected workspaces

- [x] Other — repo scaffolding and docs

## What changed

- **`pull_request_template.md`** rewritten. It asked for a GitHub issue number, but work is tracked in Notion. Now: Notion link, affected-workspace checklist flagging the three that fan out (`apps/auth`, `cadence-tokens`, `auth-permissions`), and a verification section that asks what was **actually run** rather than accepting "tested locally".
- **`.github/ISSUE_TEMPLATE/{bug,feature,chore}.yml`** as structured forms, so an agent can parse one into a plan. Bug and chore both point at the known-gaps register first.
- **`CONTRIBUTING.md`** — setup, branch naming, the verification gate **and what it does not cover**, changesets, stacked PRs, and the conventions most often missed.
- **`CODEOWNERS`**.
- **`dependabot.yml`** with 11 groups matching how these updates have been batched by hand (see the `may-2026-dep-updates-group-a/b/c` branches) — one PR per coherent area rather than twenty single-package PRs.
- **`docs/workflows/sdlc.md`** — the loop end to end, and an explicit statement of where automation deliberately stops.

## The boundary, stated explicitly

Claude runs **locally, with a person reviewing**. CI stays deterministic — lint, typecheck, test, deploy — and never writes code. The value is in agents having accurate context and a trustworthy gate, not in removing the reviewer.

## Verification

- [x] All 91 markdown files in the repo have zero broken relative links
- [x] Issue forms structurally validated (`name`/`description`/`body`, matching `type`/`attributes` counts)
- [x] `pnpm verify` passes
- [x] Scaffolding and docs only — no changeset needed

## Notes for the reviewer

Top of the stack. Merge bottom-up from #265; GitHub retargets each PR as the one below merges, but **verify it did** — a wrong base silently inflates the next diff.