### PR TITLE
chore(ci): make smoke tests independent of repository secrets

### DIFF
--- a/.github/workflows/ci-monorepo.yml
+++ b/.github/workflows/ci-monorepo.yml
@@ -8,7 +8,9 @@ on:
 
 env:
   NODE_VERSION: '20.x'
-  PNPM_VERSION: '9'
+  # pnpm's version is NOT set here. `pnpm/action-setup` v6 hard-errors if it finds a
+  # version in both the `version:` input and `packageManager` in package.json, so
+  # `packageManager: pnpm@9.15.4` is the single source of truth.
   # No job in this workflow launches a browser — E2E lives in ci-www-e2e.yml.
   # Skipping the binary download keeps installs fast across every job.
   CYPRESS_INSTALL_BINARY: '0'
@@ -23,14 +25,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@v6
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -59,14 +59,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@v6
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -85,7 +83,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: www-unit-coverage

--- a/.github/workflows/ci-www-e2e.yml
+++ b/.github/workflows/ci-www-e2e.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/ci-www-e2e.yml'
       - 'packages/cadence-**/**'
       - 'pnpm-lock.yaml'
-  
+
   # Run on push to main only if www files changed
   push:
     branches: [main]
@@ -16,7 +16,7 @@ on:
       - 'apps/www/**'
       - '.github/workflows/ci-www-e2e.yml'
       - 'packages/cadence-**/**'
-  
+
   # Allow manual triggering
   workflow_dispatch:
     inputs:
@@ -35,19 +35,56 @@ on:
 
 env:
   NODE_VERSION: '20.x'
-  PNPM_VERSION: '9'
+  # pnpm's version is NOT set here. `pnpm/action-setup` v6 hard-errors if it finds a
+  # version in both the `version:` input and `packageManager` in package.json, so
+  # `packageManager: pnpm@9.15.4` is the single source of truth.
 
 concurrency:
   group: e2e-tests-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Quick smoke tests for every PR
+  # Quick smoke tests for every PR.
+  #
+  # This job deliberately uses NO repository secrets. Dependabot-triggered `pull_request`
+  # runs read from the *Dependabot* secrets store, not the Actions one, and that store is
+  # empty — so every `${{ secrets.* }}` here used to resolve to an empty string and every
+  # Dependabot PR went red while human PRs stayed green. Rather than mirror production
+  # credentials into a second store (a job that runs `pnpm install` on not-yet-reviewed
+  # package versions, with lifecycle scripts enabled, should not hold real tokens), the
+  # job runs on throwaway values. It only visits public routes against a locally built
+  # app and a disposable Postgres, so it never needed the real ones.
+  #
+  # `full-tests` below still uses secrets: it runs on push/workflow_dispatch, where they
+  # are available.
   smoke-tests:
     name: 'Smoke Tests'
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    
+
+    env:
+      # Postgres service container, below.
+      CI_DATABASE_URL: postgresql://postgres:test_password@localhost:5432/test_db
+      # Any non-empty string satisfies Better Auth, but cypress/plugins/env-validator.ts
+      # separately enforces >= 32 characters and throws when CI is set.
+      CI_BETTER_AUTH_SECRET: ci-smoke-test-secret-not-a-production-value
+      # src/actions/email/{send-email,newsletter-subscription}.ts call `new Resend(key)`
+      # at module scope, which throws on an empty key and would 500 the /contact and
+      # /newsletter routes this spec asserts on. env-validator.ts requires the `re_`
+      # prefix if the var is set at all.
+      CI_RESEND_API_KEY: re_ci_smoke_test_key_not_real
+      # Not secrets — these exact values are already committed in
+      # apps/cms-sanity/sanity.config.ts. They are needed rather than merely nice to have:
+      # with the project id unset, sanity.client.ts patches `fetch` to return [], the
+      # homepage then renders nothing, and `cy.get('main').should('be.visible')` fails.
+      # NEXT_PUBLIC_* is inlined at build time, so these must be set before `pnpm build`.
+      CI_SANITY_PROJECT_ID: v5w3t766
+      CI_SANITY_DATASET: production
+      CI_SANITY_API_VERSION: '2022-11-15'
+      # The app under test is the one we just built, on localhost. This must never point
+      # at a deployed environment.
+      CI_APP_URL: http://localhost:3000
+
     services:
       postgres:
         image: postgres:15
@@ -62,23 +99,21 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-    
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-      
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
+
       - name: Install Cypress binary
         run: pnpm --filter www cypress:install
-      
+
       - name: Build packages
         run: |
           pnpm --filter cadence-tokens build
@@ -88,23 +123,21 @@ jobs:
       - name: Setup test environment
         working-directory: apps/www
         env:
-          DATABASE_URL: postgresql://postgres:test_password@localhost:5432/test_db
-          DATABASE_URL_AUTH: postgresql://postgres:test_password@localhost:5432/test_db
-          TEST_DATABASE_URL: postgresql://postgres:test_password@localhost:5432/test_db
+          DATABASE_URL: ${{ env.CI_DATABASE_URL }}
+          DATABASE_URL_AUTH: ${{ env.CI_DATABASE_URL }}
+          TEST_DATABASE_URL: ${{ env.CI_DATABASE_URL }}
         run: |
           cat > .env.local << EOF
-          DATABASE_URL=postgresql://postgres:test_password@localhost:5432/test_db
-          DATABASE_URL_AUTH=postgresql://postgres:test_password@localhost:5432/test_db
-          TEST_DATABASE_URL=postgresql://postgres:test_password@localhost:5432/test_db
-          BETTER_AUTH_SECRET=${{ secrets.BETTER_AUTH_SECRET }}
-          BETTER_AUTH_URL=${{ secrets.BETTER_AUTH_URL }}
-          NEXT_PUBLIC_PROJECT_URL=${{ secrets.NEXT_PUBLIC_PROJECT_URL }}
-          RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
-          NEXT_PUBLIC_SANITY_PROJECT_ID=${{ secrets.NEXT_PUBLIC_SANITY_PROJECT_ID }}
-          NEXT_PUBLIC_SANITY_DATASET=${{ secrets.NEXT_PUBLIC_SANITY_DATASET }}
-          NEXT_PUBLIC_SANITY_API_VERSION=${{ secrets.NEXT_PUBLIC_SANITY_API_VERSION }}
-          SANITY_API_TOKEN=${{ secrets.SANITY_API_TOKEN }}
-          SANITY_API_READ_TOKEN=${{ secrets.SANITY_API_READ_TOKEN }}
+          DATABASE_URL=${{ env.CI_DATABASE_URL }}
+          DATABASE_URL_AUTH=${{ env.CI_DATABASE_URL }}
+          TEST_DATABASE_URL=${{ env.CI_DATABASE_URL }}
+          BETTER_AUTH_SECRET=${{ env.CI_BETTER_AUTH_SECRET }}
+          BETTER_AUTH_URL=${{ env.CI_APP_URL }}
+          NEXT_PUBLIC_PROJECT_URL=${{ env.CI_APP_URL }}
+          RESEND_API_KEY=${{ env.CI_RESEND_API_KEY }}
+          NEXT_PUBLIC_SANITY_PROJECT_ID=${{ env.CI_SANITY_PROJECT_ID }}
+          NEXT_PUBLIC_SANITY_DATASET=${{ env.CI_SANITY_DATASET }}
+          NEXT_PUBLIC_SANITY_API_VERSION=${{ env.CI_SANITY_API_VERSION }}
           EOF
 
           # Setup database schema, seed test data, and verify test users
@@ -115,11 +148,11 @@ jobs:
         run: pnpm build
 
       - name: Run smoke tests
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           start: pnpm start
           working-directory: apps/www
-          wait-on: 'http://localhost:3000'
+          wait-on: ${{ env.CI_APP_URL }}
           wait-on-timeout: 180
           browser: chrome
           headed: false
@@ -128,18 +161,24 @@ jobs:
           config-file: cypress.config.ts
           spec: cypress/e2e/routes/public-routes.cy.ts
         env:
-          DATABASE_URL: postgresql://postgres:test_password@localhost:5432/test_db
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-          BETTER_AUTH_URL: ${{ secrets.BETTER_AUTH_URL }}
-          NEXT_PUBLIC_PROJECT_URL: ${{ secrets.NEXT_PUBLIC_PROJECT_URL }}
-          CYPRESS_BASE_URL: ${{ secrets.NEXT_PUBLIC_PROJECT_URL }}
+          DATABASE_URL: ${{ env.CI_DATABASE_URL }}
+          DATABASE_URL_AUTH: ${{ env.CI_DATABASE_URL }}
+          BETTER_AUTH_SECRET: ${{ env.CI_BETTER_AUTH_SECRET }}
+          BETTER_AUTH_URL: ${{ env.CI_APP_URL }}
+          NEXT_PUBLIC_PROJECT_URL: ${{ env.CI_APP_URL }}
+          RESEND_API_KEY: ${{ env.CI_RESEND_API_KEY }}
+          # Was `secrets.NEXT_PUBLIC_PROJECT_URL` — a deployed URL. Had that secret ever
+          # been populated, Cypress would have tested the deployed site instead of the
+          # build under review, and the PR would have gone green having exercised none of
+          # its own code.
+          CYPRESS_BASE_URL: ${{ env.CI_APP_URL }}
 
   # Full test suite for main branch and manual triggers
   full-tests:
     name: 'Full E2E Tests'
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    
+
     services:
       postgres:
         image: postgres:15
@@ -156,27 +195,28 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-      
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
+
       - name: Install Cypress binary
         run: pnpm --filter www cypress:install
-      
+
       - name: Build packages
         run: |
           pnpm --filter cadence-tokens build
           pnpm --filter cadence-icons build
           pnpm --filter cadence-core build
 
+      # BETTER_AUTH_URL / NEXT_PUBLIC_PROJECT_URL are localhost, not the secrets they used
+      # to read: this job builds and starts its own copy of the app below, so pointing
+      # them at a deployed environment would test something we did not build.
       - name: Setup test environment
         working-directory: apps/www
         env:
@@ -189,8 +229,8 @@ jobs:
           DATABASE_URL_AUTH=postgresql://postgres:test_password@localhost:5432/test_db
           TEST_DATABASE_URL=postgresql://postgres:test_password@localhost:5432/test_db
           BETTER_AUTH_SECRET=${{ secrets.BETTER_AUTH_SECRET }}
-          BETTER_AUTH_URL=${{ secrets.BETTER_AUTH_URL }}
-          NEXT_PUBLIC_PROJECT_URL=${{ secrets.NEXT_PUBLIC_PROJECT_URL }}
+          BETTER_AUTH_URL=http://localhost:3000
+          NEXT_PUBLIC_PROJECT_URL=http://localhost:3000
           RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
           NEXT_PUBLIC_SANITY_PROJECT_ID=${{ secrets.NEXT_PUBLIC_SANITY_PROJECT_ID }}
           NEXT_PUBLIC_SANITY_DATASET=${{ secrets.NEXT_PUBLIC_SANITY_DATASET }}
@@ -216,7 +256,7 @@ jobs:
           fi
 
       - name: Run E2E tests
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         continue-on-error: true
         with:
           start: pnpm start
@@ -231,13 +271,17 @@ jobs:
           spec: ${{ steps.test-suite.outputs.suite == 'all' && 'cypress/e2e/**/*.cy.ts' || format('cypress/e2e/{0}/**/*.cy.ts', steps.test-suite.outputs.suite) }}
         env:
           DATABASE_URL: postgresql://postgres:test_password@localhost:5432/test_db
+          DATABASE_URL_AUTH: postgresql://postgres:test_password@localhost:5432/test_db
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-          BETTER_AUTH_URL: ${{ secrets.BETTER_AUTH_URL }}
-          NEXT_PUBLIC_PROJECT_URL: ${{ secrets.NEXT_PUBLIC_PROJECT_URL }}
-          CYPRESS_BASE_URL: ${{ secrets.NEXT_PUBLIC_PROJECT_URL }}
-      
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          # Localhost, not a deployed URL — this job builds and starts its own copy of the
+          # app above, and pointing Cypress elsewhere would test something we did not build.
+          BETTER_AUTH_URL: http://localhost:3000
+          NEXT_PUBLIC_PROJECT_URL: http://localhost:3000
+          CYPRESS_BASE_URL: http://localhost:3000
+
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: cypress-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
+      # No `version:` input — v6 errors if the version is also in package.json's
+      # `packageManager`, which it is.
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: 'pnpm'


### PR DESCRIPTION
## Why

All six open Dependabot PRs (#272–#277) are red, and none of the failures are caused by the dependency bumps. Two pre-existing CI defects surface only on Dependabot-authored PRs.

**Cause A — Dependabot PRs cannot read Actions secrets (all six).** GitHub runs Dependabot-triggered `pull_request` workflows against a separate *Dependabot* secrets store, which is empty on this repo:

```
Actions secrets:    BETTER_AUTH_SECRET, NEON_API_KEY, NEXT_PUBLIC_SANITY_DATASET,
                    NEXT_PUBLIC_SANITY_PROJECT_ID, RESEND_API_KEY, SANITY_API_TOKEN
Dependabot secrets: (none)
```

So `BETTER_AUTH_SECRET` resolved to an empty string. `src/lib/auth/auth.ts` evaluates `getAuth()` at module import, Better Auth throws on the default secret under `NODE_ENV=production`, and `proxy.ts` imports it on every request — every page 500'd, `wait-on` never saw a 200, and the job died after 210s. The same job is green on every human PR.

**Cause B — `pnpm/action-setup@v6` rejects a duplicate pnpm version (#272 only).**

```
Error: Multiple versions of pnpm specified:
  - version 9 in the GitHub Action config with the key "version"
  - version pnpm@9.15.4 in the package.json with the key "packageManager"
```

## What changed

The smoke job runs one spec against public routes on a locally built app and a disposable Postgres — it never needed production credentials. It now references **no secrets at all**, so Dependabot and human PRs take an identical path:

| Var | Value | Why |
|---|---|---|
| `BETTER_AUTH_SECRET` | 43-char CI constant | Better Auth accepts any non-default value; `env-validator.ts` separately requires ≥32 chars |
| `RESEND_API_KEY` | dummy `re_` key | `send-email.ts` / `newsletter-subscription.ts` call `new Resend(key)` at module scope, which throws on an empty key and would 500 `/contact` and `/newsletter` — both asserted by the spec |
| Sanity project id / dataset | the values already committed in `apps/cms-sanity/sanity.config.ts` | Not secrets. Required, not decorative: unset, `sanity.client.ts` patches `fetch` to return `[]`, the homepage renders nothing, and `cy.get('main').should('be.visible')` fails |

Real Sanity tokens are dropped from this job entirely — published reads don't use them.

Also fixes **`CYPRESS_BASE_URL` in both E2E jobs**. It read `secrets.NEXT_PUBLIC_PROJECT_URL`, a deployed URL. Had that secret ever been populated, Cypress would have tested the deployed site instead of the build under review, and the PR would have gone green having exercised none of its own code.

Drops the `version:` input from every `pnpm/action-setup` step; `packageManager: pnpm@9.15.4` is now the single source of truth.

**Supersedes #272** — includes its action bumps (checkout v4→v7, setup-node v4→v7, upload-artifact v4→v7, action-setup v2→v6, cypress-io v6→v7) plus `release.yml`, which #272 also covered.

### Why not just add Dependabot secrets

`gh secret set X --app dependabot` would turn all six green in one command. Rejected: this repo has no `onlyBuiltDependencies` allowlist, so `pnpm install --frozen-lockfile` runs lifecycle scripts from the very package versions under review. Putting `SANITY_API_TOKEN` and `RESEND_API_KEY` within reach of that is a live exfiltration path. `pull_request_target` is a worse version of the same problem.

## Verification

`pnpm verify` passes (21/21 tasks, 153 tests).

Docker/Postgres aren't available on the dev machine, so the full containerised repro couldn't run locally. Instead the app was built and booted with **exactly** the literals this workflow now sets:

- `next build` succeeds; every route is `ƒ` (dynamic), which is why the broken build still passed in CI — the failures are all at request time.
- All eight routes the spec visits return **200** (`/`, `/articles`, `/handbook`, `/lexicon`, `/contributors`, `/about`, `/contact`, `/newsletter`), where previously every one 500'd.
- No `BetterAuthError`, no Resend `Missing API key`, no unhandled rejections in the server log.
- Homepage `<main>` renders ~28KB of content, confirming the Sanity literals resolve real published data rather than the empty-array fallback.
- `/contact` renders all four of its form inputs — the module-scope Resend constructor no longer throws.

Because the smoke job now references zero secrets, **this PR's own `Smoke Tests` run exercises the same path a Dependabot run takes** — a green check here is a faithful simulation of the fix.

## Follow-up (not in this PR)

Once merged, `@dependabot rebase` on #273, #274, #276, #277 and merge in ascending risk: #277 (pg), #274 (react patch), #273 (next patch), #276 (better-auth).

**#275 should not be merged on a green check.** It's eight Sanity packages including four majors (`sanity` 5→6, `next-sanity` 12→13, `@portabletext/react` 6→7, `sanity-plugin-media` 4→6). Those change rendering and fetching APIs that `pnpm typecheck` won't reliably catch, and per `AGENTS.md` this app renders empty rather than failing when Sanity is misconfigured — so a green suite proves less than usual there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WroRUUPaFLtSssd1zMPUNb