### PR TITLE
feat(www): instrument educational content and enrich identification

### DIFF
--- a/.changeset/posthog-content-instrumentation.md
+++ b/.changeset/posthog-content-instrumentation.md
@@ -1,0 +1,21 @@
+---
+'www': minor
+---
+
+Instrument educational content and enrich person identification.
+
+Nothing about content engagement was tracked, on a site whose whole purpose is
+educational content. Adds `article_viewed`, `handbook_page_viewed`,
+`lexicon_term_viewed`, `category_browsed`, and `contributor_viewed` via a shared
+`TrackContentView` component, mounted from the server component that already fetched
+the slug and title — so the analytics cannot disagree with what was rendered.
+
+Adds `article_read`, which fires when the reader reaches the end of an article. Paired
+with `article_viewed` it gives a completion rate, which is the question actually worth
+asking of a lesson.
+
+Adds `notation_rendered` on the first successful OSMD render, so it is possible to tell
+whether the music-notation feature is used and whether it renders successfully.
+
+`PostHogIdentify` now sets `email`, `role`, and `is_admin` alongside `name`. Without
+`is_admin` there was no way to exclude staff traffic from product metrics.

--- a/apps/www/AGENTS.md
+++ b/apps/www/AGENTS.md
@@ -126,6 +126,12 @@ declared properties compile. `posthog.capture` accepts any string. `posthog.rese
 (`components/navigation/main/header-navigation.tsx`) is a legitimate direct use — it is not a
 capture.
 
+Content routes are instrumented with `<TrackContentView>` from `components/analytics`, mounted
+from the server component that already fetched the record. Pass the slug and title from that same
+fetch rather than re-deriving them, so the event cannot disagree with what was rendered. The
+component is keyed on `event:slug`, not a boolean, because App Router reuses it across
+navigations within a route — a boolean would swallow every article after the first.
+
 ## Gotchas
 
 - **Sanity failures are silent.** `src/lib/sanity/sanity.client.ts` monkey-patches

--- a/apps/www/src/app/(pages)/(educational-content)/articles/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/(educational-content)/articles/[slug]/page.tsx
@@ -14,6 +14,8 @@ import { RichText, RichTextWrapper } from '@components/rich-text'
 import { NewsletterSignup } from '@components/newsletter-signup'
 import { TableOfContents } from '@components/table-of-contents'
 import { ReadingLength } from '@components/reading-length'
+import calculateReadingLength from '@components/reading-length/calculateReadingLength'
+import { TrackArticleRead, TrackContentView } from '@components/analytics'
 import { ChangelogDrawer } from '@components/changelog'
 import s from './page.module.css'
 
@@ -137,6 +139,16 @@ export default async function ArticleSlugRoute({ params }: PageProps) {
 					title="On this page"
 				/>
 			</Flex>
+			<TrackContentView
+				event="article_viewed"
+				slug={slug}
+				title={article.title}
+			/>
+			<TrackArticleRead
+				slug={slug}
+				title={article.title}
+				readingTimeMinutes={calculateReadingLength(article.content.content)}
+			/>
 		</>
 	)
 }

--- a/apps/www/src/app/(pages)/(educational-content)/categories/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/(educational-content)/categories/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { getOgTitle } from '@utils/metaHelpers'
 import { linkResolver } from '@utils/link-resolver'
 import { Text, SectionContainer, SectionTitle } from 'cadence-core'
 import { ListItem } from '@components/list'
+import { TrackContentView } from '@components/analytics'
 
 import type { Metadata, ResolvingMetadata } from 'next'
 import type { MetaProps } from '../../../../../types/meta'
@@ -114,6 +115,11 @@ export default async function CategorySlugRoute({ params }: { params: Promise<{ 
 					/>
 				)
 			})}
+			<TrackContentView
+				event="category_browsed"
+				slug={slug}
+				title={category.title}
+			/>
 		</SectionContainer>
 	)
 }

--- a/apps/www/src/app/(pages)/(educational-content)/handbook/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/(educational-content)/handbook/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { Text, SectionContainer, SectionTitle } from 'cadence-core'
 import { Link } from '@components/link'
 import { RichText, RichTextWrapper } from '@components/rich-text'
 import { ChangelogDrawer } from '@components/changelog'
+import { TrackContentView } from '@components/analytics'
 import s from './handbook-page.module.css'
 
 import type { Metadata, ResolvingMetadata } from 'next'
@@ -108,6 +109,11 @@ export default async function HandbookSlugRoute({ params }: { params: Promise<{ 
 					<RichText value={handbook.content.content} />
 				</RichTextWrapper>
 			</SectionContainer>
+			<TrackContentView
+				event="handbook_page_viewed"
+				slug={slug}
+				title={handbook.title}
+			/>
 		</>
 	)
 }

--- a/apps/www/src/app/(pages)/(educational-content)/lexicon/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/(educational-content)/lexicon/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { getSanityUrl } from '@utils/getSanityUrl'
 import { RichText } from '@components/rich-text'
 import { MusicNotation } from '@components/music-notation'
 import { ChangelogDrawer } from '@components/changelog'
+import { TrackContentView } from '@components/analytics'
 
 import s from './lexicon-page.module.css'
 import type { SlugParams, SlugString } from '../../../../../types/common'
@@ -86,6 +87,12 @@ export default async function LexiconSlugRoute({ params }: { params: Promise<{ s
 		excerpt,
 		audio,
 	} = lexicon
+
+	// A lexicon entry has no single title field — the same artist/album/track
+	// composition used for the page metadata, so analytics and the OG title
+	// agree on what this entry is called.
+	const lexiconEntryTitle =
+		[artist, album, track].filter(Boolean).join(' - ') || 'Lexicon'
 
 	const lexiconMetadata = [
 		{
@@ -170,6 +177,11 @@ export default async function LexiconSlugRoute({ params }: { params: Promise<{ s
 					</Flex>
 				</section>
 			</SectionContainer>
+			<TrackContentView
+				event="lexicon_term_viewed"
+				slug={slug}
+				title={lexiconEntryTitle}
+			/>
 		</>
 	)
 }

--- a/apps/www/src/app/(pages)/contributors/[slug]/page.tsx
+++ b/apps/www/src/app/(pages)/contributors/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { Text, Flex, SectionContainer, SectionTitle } from 'cadence-core'
 import { RichText } from '@components/rich-text'
 import * as FeaturedItem from '@components/featured-item'
 import { ListItem } from '@components/list'
+import { TrackContentView } from '@components/analytics'
 import { linkResolver } from '@utils/link-resolver'
 
 import type { Metadata, ResolvingMetadata } from 'next'
@@ -115,6 +116,11 @@ export default async function ContributorSlugRoute({ params }: { params: Promise
 					))}
 				</Flex>
 			</SectionContainer>
+			<TrackContentView
+				event="contributor_viewed"
+				slug={slug}
+				title={contributor.name}
+			/>
 		</>
 	)
 }

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { NuqsAdapter } from 'nuqs/adapters/next/app'
 import Fathom from '@lib/fathom'
 import { AppFrame } from '@components/app-frame'
 import { Provider } from './provider'
+import { isAdmin } from 'auth-permissions'
 import { getOptionalSession } from '@/lib/auth/require-auth'
 import { PostHogIdentify } from '@components/posthog-identify/posthog-identify'
 import '@styles/index.css'
@@ -26,6 +27,9 @@ export default async function RootLayout({
 					<PostHogIdentify
 						userId={session.user.id}
 						name={session.user.name}
+						email={session.user.email}
+						role={(session.user as { role?: string }).role}
+						isAdmin={isAdmin(session)}
 					/>
 				)}
 			</body>

--- a/apps/www/src/components/analytics/__test__/track-article-read.test.tsx
+++ b/apps/www/src/components/analytics/__test__/track-article-read.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+const { capture } = vi.hoisted(() => ({ capture: vi.fn() }))
+
+vi.mock('@lib/posthog/capture', () => ({ capture }))
+
+const { TrackArticleRead } = await import('../track-article-read')
+
+/**
+ * jsdom has no IntersectionObserver. This stub records the callback so a test
+ * can decide when the end of the article comes into view.
+ */
+let triggerIntersection: (isIntersecting: boolean) => void
+let disconnected = false
+
+class MockIntersectionObserver {
+	constructor(callback: IntersectionObserverCallback) {
+		triggerIntersection = (isIntersecting: boolean) => {
+			callback(
+				[{ isIntersecting } as IntersectionObserverEntry],
+				this as unknown as IntersectionObserver
+			)
+		}
+	}
+
+	observe() {}
+	disconnect() {
+		disconnected = true
+	}
+	unobserve() {}
+	takeRecords(): IntersectionObserverEntry[] {
+		return []
+	}
+}
+
+const props = {
+	slug: 'swing-feel',
+	title: 'Swing Feel',
+	readingTimeMinutes: 7,
+}
+
+describe('TrackArticleRead', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		disconnected = false
+		vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+	})
+
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	it('does not capture on mount', () => {
+		render(<TrackArticleRead {...props} />)
+
+		expect(capture).not.toHaveBeenCalled()
+	})
+
+	it('does not capture while the end of the article is out of view', () => {
+		render(<TrackArticleRead {...props} />)
+
+		triggerIntersection(false)
+
+		expect(capture).not.toHaveBeenCalled()
+	})
+
+	it('captures once the end of the article comes into view', () => {
+		render(<TrackArticleRead {...props} />)
+
+		triggerIntersection(true)
+
+		expect(capture).toHaveBeenCalledWith('article_read', {
+			slug: 'swing-feel',
+			title: 'Swing Feel',
+			reading_time_minutes: 7,
+		})
+	})
+
+	it('captures only once, and stops observing afterwards', () => {
+		render(<TrackArticleRead {...props} />)
+
+		triggerIntersection(true)
+		triggerIntersection(true)
+
+		expect(capture).toHaveBeenCalledTimes(1)
+		expect(disconnected).toBe(true)
+	})
+
+	it('renders nothing visible', () => {
+		const { container } = render(<TrackArticleRead {...props} />)
+
+		expect(container.textContent).toBe('')
+		expect(container.firstElementChild?.getAttribute('aria-hidden')).toBe(
+			'true'
+		)
+	})
+
+	it('captures nothing when IntersectionObserver is unavailable', () => {
+		// Undercounting is the right failure — a fabricated completion would be
+		// worse than a missing one.
+		vi.stubGlobal('IntersectionObserver', undefined)
+
+		expect(() => render(<TrackArticleRead {...props} />)).not.toThrow()
+		expect(capture).not.toHaveBeenCalled()
+	})
+})

--- a/apps/www/src/components/analytics/__test__/track-content-view.test.tsx
+++ b/apps/www/src/components/analytics/__test__/track-content-view.test.tsx
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+const { capture } = vi.hoisted(() => ({ capture: vi.fn() }))
+
+vi.mock('@lib/posthog/capture', () => ({ capture }))
+
+const { TrackContentView } = await import('../track-content-view')
+
+describe('TrackContentView', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('captures the event once on mount', () => {
+		render(
+			<TrackContentView
+				event="article_viewed"
+				slug="swing-feel"
+				title="Swing Feel"
+			/>
+		)
+
+		expect(capture).toHaveBeenCalledTimes(1)
+		expect(capture).toHaveBeenCalledWith('article_viewed', {
+			slug: 'swing-feel',
+			title: 'Swing Feel',
+		})
+	})
+
+	it('does not re-capture when the component re-renders with the same content', () => {
+		const { rerender } = render(
+			<TrackContentView
+				event="article_viewed"
+				slug="swing-feel"
+				title="Swing Feel"
+			/>
+		)
+
+		rerender(
+			<TrackContentView
+				event="article_viewed"
+				slug="swing-feel"
+				title="Swing Feel"
+			/>
+		)
+
+		expect(capture).toHaveBeenCalledTimes(1)
+	})
+
+	it('captures again when the reader navigates to different content', () => {
+		// App Router reuses this component across navigations within the same
+		// route, so a plain "already fired" boolean would silently swallow every
+		// article after the first.
+		const { rerender } = render(
+			<TrackContentView
+				event="article_viewed"
+				slug="swing-feel"
+				title="Swing Feel"
+			/>
+		)
+
+		rerender(
+			<TrackContentView
+				event="article_viewed"
+				slug="tritone-substitution"
+				title="Tritone Substitution"
+			/>
+		)
+
+		expect(capture).toHaveBeenCalledTimes(2)
+		expect(capture).toHaveBeenLastCalledWith('article_viewed', {
+			slug: 'tritone-substitution',
+			title: 'Tritone Substitution',
+		})
+	})
+
+	it('carries the event name it was given', () => {
+		render(
+			<TrackContentView
+				event="lexicon_term_viewed"
+				slug="ii-v-i"
+				title="Miles Davis - Kind of Blue - So What"
+			/>
+		)
+
+		expect(capture).toHaveBeenCalledWith('lexicon_term_viewed', {
+			slug: 'ii-v-i',
+			title: 'Miles Davis - Kind of Blue - So What',
+		})
+	})
+})

--- a/apps/www/src/components/analytics/index.ts
+++ b/apps/www/src/components/analytics/index.ts
@@ -1,0 +1,8 @@
+export { TrackContentView } from './track-content-view'
+export type {
+	ContentViewEvent,
+	TrackContentViewProps,
+} from './track-content-view'
+
+export { TrackArticleRead } from './track-article-read'
+export type { TrackArticleReadProps } from './track-article-read'

--- a/apps/www/src/components/analytics/track-article-read.tsx
+++ b/apps/www/src/components/analytics/track-article-read.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { capture } from '@lib/posthog/capture'
+
+export type TrackArticleReadProps = {
+	slug: string
+	title: string
+	/** From `calculateReadingLength`, the same estimate shown by `ReadingLength`. */
+	readingTimeMinutes: number
+}
+
+/**
+ * Captures `article_read` when the reader reaches the end of the article.
+ *
+ * "Read" here means *reached the bottom* — a deliberately simple, explainable
+ * definition. Paired with `article_viewed` it gives a completion rate, which is
+ * the question actually worth asking of an education site: not how many people
+ * landed on a lesson, but how many finished it.
+ *
+ * It is a proxy, not proof of reading. Someone who scrolls straight to the
+ * bottom counts. That is an acceptable overcount; the alternatives (scroll-depth
+ * sampling, time-on-page heuristics) are more code and no more honest.
+ *
+ * Renders a zero-height sentinel at the end of the article and watches it,
+ * rather than measuring scroll position, so it stays correct regardless of page
+ * length, zoom, or viewport.
+ */
+export function TrackArticleRead({
+	slug,
+	title,
+	readingTimeMinutes,
+}: TrackArticleReadProps) {
+	const sentinelRef = useRef<HTMLDivElement>(null)
+	const lastCaptured = useRef<string | null>(null)
+
+	useEffect(() => {
+		const sentinel = sentinelRef.current
+		if (!sentinel) return
+
+		// Older browsers without IntersectionObserver simply never fire the
+		// event. Undercounting is the right failure here — a fabricated
+		// completion would be worse than a missing one.
+		if (typeof IntersectionObserver === 'undefined') return
+
+		const observer = new IntersectionObserver((entries) => {
+			for (const entry of entries) {
+				if (!entry.isIntersecting) continue
+
+				const key = `article_read:${slug}`
+				if (lastCaptured.current === key) return
+
+				lastCaptured.current = key
+				capture('article_read', {
+					slug,
+					title,
+					reading_time_minutes: readingTimeMinutes,
+				})
+
+				observer.disconnect()
+			}
+		})
+
+		observer.observe(sentinel)
+
+		return () => observer.disconnect()
+	}, [slug, title, readingTimeMinutes])
+
+	return <div ref={sentinelRef} aria-hidden="true" />
+}

--- a/apps/www/src/components/analytics/track-content-view.tsx
+++ b/apps/www/src/components/analytics/track-content-view.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { capture } from '@lib/posthog/capture'
+
+/**
+ * The events that describe "someone looked at a piece of content". All share
+ * the same `{ slug, title }` shape, which is what lets one component serve
+ * every content route.
+ */
+export type ContentViewEvent =
+	| 'article_viewed'
+	| 'handbook_page_viewed'
+	| 'lexicon_term_viewed'
+	| 'category_browsed'
+	| 'contributor_viewed'
+
+export type TrackContentViewProps = {
+	event: ContentViewEvent
+	slug: string
+	title: string
+}
+
+/**
+ * Captures a content-view event once per piece of content.
+ *
+ * Mounted from the server component that renders the content, so the slug and
+ * title come from the same Sanity fetch that renders the page — no second
+ * query, and no risk of the analytics disagreeing with what was displayed.
+ *
+ * PostHog's own `$pageview` already records that a URL was visited. This exists
+ * because `$pageview` carries only the path: reporting on it means parsing
+ * slugs out of URLs and joining back to Sanity for titles.
+ */
+export function TrackContentView({ event, slug, title }: TrackContentViewProps) {
+	// Keyed on the content rather than a plain boolean: App Router reuses this
+	// component across navigations within the same route, so a boolean would
+	// suppress the event for every article after the first. The key also makes
+	// this idempotent under StrictMode's double-invoked effects.
+	const lastCaptured = useRef<string | null>(null)
+
+	useEffect(() => {
+		const key = `${event}:${slug}`
+		if (lastCaptured.current === key) return
+
+		lastCaptured.current = key
+		capture(event, { slug, title })
+	}, [event, slug, title])
+
+	return null
+}

--- a/apps/www/src/components/music-notation/music-notation/osmd-component.tsx
+++ b/apps/www/src/components/music-notation/music-notation/osmd-component.tsx
@@ -1,11 +1,13 @@
 'use client'
 
 import { useState, useEffect, useRef, useMemo, useCallback, memo } from 'react'
+import { usePathname } from 'next/navigation'
 import {
 	EngravingRules,
 	OpenSheetMusicDisplay as OSMD,
 	TransposeCalculator,
 } from 'opensheetmusicdisplay'
+import { capture } from '@lib/posthog/capture'
 import type { OpenSheetMusicDisplayProps } from './types'
 
 interface ExtendedOpenSheetMusicDisplayProps
@@ -40,6 +42,13 @@ const OpenSheetMusicDisplay = ({
 	const osmd = useRef<OSMD | null>(null)
 	const initialRenderComplete = useRef(false)
 	const loadComplete = useRef(false)
+	const analyticsCapturedFor = useRef<typeof file | null>(null)
+
+	// The slug of the page the notation sits on. Derived from the path rather
+	// than threaded down as a prop, so this stays a drop-in for every caller —
+	// `MusicNotation` is used from both article and lexicon routes.
+	const pathname = usePathname()
+	const currentSlug = pathname?.split('/').filter(Boolean).pop() ?? null
 
 	const osmdOptions = useMemo(() => ({
 		autoResize,
@@ -142,6 +151,16 @@ const OpenSheetMusicDisplay = ({
 							await osmd.current.render()
 							initialRenderComplete.current = true
 							setError(null)
+
+							// Only the first successful render of a given file.
+							// The resize and transpose effects below also call
+							// `render()`, and `onRenderComplete` fires on failure
+							// too — neither is a "the reader saw notation" signal.
+							if (analyticsCapturedFor.current !== file) {
+								analyticsCapturedFor.current = file
+								capture('notation_rendered', { slug: currentSlug })
+							}
+
 							onRenderComplete?.()
 						} catch (renderError) {
 							console.error('Render error:', renderError)

--- a/apps/www/src/components/posthog-identify/__test__/posthog-identify.test.tsx
+++ b/apps/www/src/components/posthog-identify/__test__/posthog-identify.test.tsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+const { identify } = vi.hoisted(() => ({ identify: vi.fn() }))
+
+vi.mock('posthog-js', () => ({ default: { identify } }))
+
+const { PostHogIdentify } = await import('../posthog-identify')
+
+const props = {
+	userId: 'user_abc123',
+	name: 'Ella Fitzgerald',
+	email: 'ella@example.com',
+	role: 'user',
+	isAdmin: false,
+}
+
+describe('PostHogIdentify', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('identifies by the better-auth user id', () => {
+		// This id is what stitches `www` events to the auth-funnel events
+		// captured in `apps/auth`. The two apps are on different domains, so
+		// there is no shared cookie and no common anonymous id to fall back on.
+		render(<PostHogIdentify {...props} />)
+
+		expect(identify).toHaveBeenCalledWith('user_abc123', expect.any(Object))
+	})
+
+	it('sets the person properties', () => {
+		render(<PostHogIdentify {...props} />)
+
+		expect(identify).toHaveBeenCalledWith('user_abc123', {
+			name: 'Ella Fitzgerald',
+			email: 'ella@example.com',
+			role: 'user',
+			is_admin: false,
+		})
+	})
+
+	it('flags admins so staff traffic can be excluded from product metrics', () => {
+		render(<PostHogIdentify {...props} role="admin" isAdmin />)
+
+		expect(identify).toHaveBeenCalledWith(
+			'user_abc123',
+			expect.objectContaining({ is_admin: true, role: 'admin' })
+		)
+	})
+
+	it('sends undefined rather than null for missing fields', () => {
+		// PostHog stores an explicit null as a value; undefined is omitted.
+		render(
+			<PostHogIdentify
+				userId="user_abc123"
+				name={null}
+				email={null}
+				role={null}
+				isAdmin={false}
+			/>
+		)
+
+		expect(identify).toHaveBeenCalledWith('user_abc123', {
+			name: undefined,
+			email: undefined,
+			role: undefined,
+			is_admin: false,
+		})
+	})
+})

--- a/apps/www/src/components/posthog-identify/posthog-identify.tsx
+++ b/apps/www/src/components/posthog-identify/posthog-identify.tsx
@@ -4,16 +4,40 @@ import { useEffect } from 'react'
 import posthog from 'posthog-js'
 
 interface PostHogIdentifyProps {
-  userId: string
-  name: string | null | undefined
+	userId: string
+	name: string | null | undefined
+	email: string | null | undefined
+	role: string | null | undefined
+	isAdmin: boolean
 }
 
-export function PostHogIdentify({ userId, name }: PostHogIdentifyProps) {
-  useEffect(() => {
-    posthog.identify(userId, {
-      name: name ?? undefined,
-    })
-  }, [userId, name])
+/**
+ * Associates the current PostHog person with the signed-in user.
+ *
+ * `distinct_id` is the better-auth `user.id`, which is also what `apps/auth`
+ * captures its funnel events against — that shared id is what stitches events
+ * from the two apps onto one person. They sit on different domains
+ * (`downbeatacademy.com` and `auth.downbeatacademy.services`), so there is no
+ * shared cookie to rely on and no anonymous id in common.
+ */
+export function PostHogIdentify({
+	userId,
+	name,
+	email,
+	role,
+	isAdmin,
+}: PostHogIdentifyProps) {
+	useEffect(() => {
+		posthog.identify(userId, {
+			name: name ?? undefined,
+			email: email ?? undefined,
+			role: role ?? undefined,
+			// Without this there is no way to exclude staff traffic from product
+			// metrics — a small team browsing its own site is a large fraction of
+			// its own numbers.
+			is_admin: isAdmin,
+		})
+	}, [userId, name, email, role, isAdmin])
 
-  return null
+	return null
 }


### PR DESCRIPTION
Stacked on #282. Notion: [🧪 Test PostHog Events](https://app.notion.com/p/3b331f290eb3805a8a63ce1a3a1fdba0)

Third of five. #281 fixed the setup, #282 fixed the event surface — this adds the events that were missing entirely.

## The gap this closes

This is a music education platform, and **no educational content engagement was tracked at all**. The wizard integration covered four forms and a dead auth path. Articles, the handbook, the lexicon, categories, contributors, and the notation renderer had nothing.

| Event | Where |
| --- | --- |
| `article_viewed` | `articles/[slug]` |
| `article_read` | `articles/[slug]` |
| `handbook_page_viewed` | `handbook/[slug]` |
| `lexicon_term_viewed` | `lexicon/[slug]` |
| `category_browsed` | `categories/[slug]` |
| `contributor_viewed` | `contributors/[slug]` |
| `notation_rendered` | the OSMD component |

## Design decisions worth reviewing

**`TrackContentView` is mounted from the server component**, taking the slug and title from the same Sanity fetch that rendered the page. No second query, and the event cannot disagree with what was displayed.

It is keyed on `event:slug`, not a boolean. App Router reuses the component across navigations within a route, so a boolean would silently swallow every article after the first. The key also makes it idempotent under StrictMode's double-invoked effects. There is a test for exactly this.

**`article_read` means "reached the bottom".** A deliberately simple, explainable definition — and a proxy, not proof. Someone who scrolls straight to the end counts. That overcount is acceptable; scroll-depth sampling and time-on-page heuristics are more code and no more honest. It uses a zero-height sentinel plus IntersectionObserver rather than scroll maths, so it stays correct across page length, zoom, and viewport. Where IntersectionObserver is missing it captures nothing — undercounting beats fabricating a completion.

**`notation_rendered` fires on first successful render only.** The component's existing `onRenderComplete` callback was not usable for this: it fires on the failure path too, and the resize and transpose effects re-render the same sheet. The slug comes from `usePathname` rather than a new prop, because `MusicNotation` is called from both the article and lexicon routes and threading a prop through the memoized chain would touch every caller.

**Lexicon entries have no single title field** — the page composes one from artist/album/track for its OG metadata. The event reuses that same composition so analytics and the page title agree.

**`is_admin` on the person profile** is the one that matters most in practice. Without it there is no way to exclude staff traffic from product metrics, and a small team browsing its own site is a large fraction of its own numbers.

## Verification

`pnpm verify` passes — 23/23 tasks. 14 new tests covering: capture-once-per-content, re-capture on navigation, the intersection threshold, single-fire plus disconnect, the missing-IntersectionObserver path, and the identify property shape.

## Scope note

I planned this as a 4-PR stack and it is now 5. `apps/auth` instrumentation was going to ride along here, but this PR is already large and the two touch different apps — a natural seam. It follows as its own PR, then the Cypress and QA layer last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)