### PR TITLE
feat(auth): instrument the authentication funnel

### DIFF
--- a/.changeset/posthog-auth-funnel.md
+++ b/.changeset/posthog-auth-funnel.md
@@ -1,0 +1,27 @@
+---
+'auth': minor
+'analytics': patch
+---
+
+Instrument the authentication funnel in `apps/auth`.
+
+Sign-in happens in the OAuth provider, not in the consumer apps, so the funnel was
+completely unmeasured — the previous events lived in `apps/www` on its disabled
+email-auth path and never fired.
+
+Server-side only (`posthog-node`), no client init: `auth` and `www` are on different
+domains, so a browser SDK here would create a second anonymous-identity pool with nothing
+to stitch it to the first. Capturing against the better-auth `user.id` — the same id `www`
+identifies with — avoids that entirely.
+
+`sign_up_completed` and `sign_in_completed` hang off better-auth `databaseHooks`, so every
+entry point is covered without annotating each route. `sign_out_completed` is captured in
+the sign-out page, which is where consumer apps redirect to clear the session.
+`password_reset_requested` moves to `sendResetPassword`.
+
+Adds a `test` script to `apps/auth`, which previously had no unit tests at all.
+
+Removes `password_reset_completed` and `oauth_authorization_granted` from the taxonomy.
+They were declared but not captured anywhere, and a declared-but-dead event is
+indistinguishable from a broken one in a dashboard — which is the exact failure this work
+exists to fix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ typeface-* ─────┘                  └─→ cadence-links
 
 cadence-tokens ───→ cadence-core-web-components   (no consumer)
 auth-permissions ─→ www, auth, cadence-links      (raw source, no build)
-analytics ────────→ www                           (raw source, no build)
+analytics ────────→ www, auth                     (raw source, no build)
 email ────────────→ auth only                     (raw source, no build)
 
 cms-sanity ── no workspace dependencies at all
@@ -108,7 +108,7 @@ pnpm lint          # eslint — www, auth, cadence-links, cms-sanity
 pnpm typecheck     # tsc --noEmit — every workspace
 pnpm test          # vitest run — www, cadence-links, cadence-core,
                    #   cadence-core-web-components, cadence-icons, auth-permissions,
-                   #   analytics
+                   #   analytics, auth
 ```
 
 `pnpm test` runs **once and exits**. If you ever see it hang, something has

--- a/apps/auth/AGENTS.md
+++ b/apps/auth/AGENTS.md
@@ -32,7 +32,39 @@ pnpm --filter auth db:verify-roles
 pnpm --filter auth db:fix-roles
 ```
 
-There is no `test` script — this app has no unit tests, only the five Cypress specs.
+`pnpm --filter auth test` runs vitest in a **node** environment (everything unit-tested here
+is server-side), over `src/**/__test__/**/*.test.ts`. Coverage is currently the analytics
+gate and auth-method resolution only — the five Cypress specs remain the main safety net.
+
+## Analytics
+
+This app owns the **authentication funnel**. Sign-in happens here, in the OAuth provider,
+not in the consumer apps — `apps/www` only ever receives the resulting session. Events
+previously lived in `www` on its disabled email-auth path and never fired once.
+
+Capture goes through `src/lib/analytics`, never `posthog-node` directly:
+
+- `sign_up_completed` and `sign_in_completed` hang off better-auth `databaseHooks`
+  (`user.create.after`, `session.create.after`). Hooking the database rather than the route
+  handlers means every entry point is covered — email and OAuth alike — with nothing to
+  remember when a new one is added.
+- `session.create.after` fires for reasons other than someone signing in. `resolveAuthMethod`
+  returns `null` for any path that is not a recognised sign-in entry point, and the hook
+  bails on `null`. Removing that guard silently inflates the sign-in count with session
+  refreshes.
+- `sign_out_completed` is captured in `src/app/sign-out/page.tsx`, reading the session
+  *before* `auth.api.signOut()` destroys it. That page is the real sign-out path — consumer
+  apps redirect to it — so instrumenting it covers all of them.
+- `captureAuthEvent` never throws and is never awaited. It runs on the critical path of
+  signing in; analytics must not be able to fail an authentication.
+- `distinctId` is always the better-auth `user.id`. That shared id is the *only* thing
+  stitching these events to `www`'s — the two apps are on different domains, so there is no
+  shared cookie and no common anonymous id.
+
+Like `www`, capture is gated by host: `shouldCaptureAuthAnalytics` requires `AUTH_SERVICE_URL`
+to be the production auth service. Gating on `NODE_ENV` would not work, because preview
+deploys also run with `NODE_ENV=production`. Set `POSTHOG_DEBUG=true` to capture from a local
+run — those events go to the production project.
 
 ## Layout
 

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -12,6 +12,8 @@
 		"start": "next start",
 		"lint": "eslint .",
 		"typecheck": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest",
 		"cypress": "cypress open",
 		"cypress:run": "cypress run",
 		"test:e2e": "start-server-and-test dev:ci http://localhost:3002 cypress:run",
@@ -25,6 +27,7 @@
 		"@hookform/resolvers": "^5.2.2",
 		"@radix-ui/react-tabs": "^1.1.13",
 		"@radix-ui/react-toast": "^1.2.15",
+		"analytics": "workspace:^",
 		"auth-permissions": "workspace:^",
 		"better-auth": "^1.6.25",
 		"cadence-core": "workspace:^",
@@ -35,6 +38,7 @@
 		"email": "workspace:^",
 		"next": "^16.2.12",
 		"pg": "^8.22.0",
+		"posthog-node": "^5.46.1",
 		"react": "^19.2.8",
 		"react-dom": "^19.2.8",
 		"react-hook-form": "^7.75.0",
@@ -53,6 +57,8 @@
 		"eslint": "^9.39.2",
 		"eslint-config-next": "^16.2.12",
 		"start-server-and-test": "^2.1.5",
-		"typescript": "^5.9.3"
+		"typescript": "^5.9.3",
+		"vite-tsconfig-paths": "^6.0.5",
+		"vitest": "^4.1.6"
 	}
 }

--- a/apps/auth/src/app/sign-out/page.tsx
+++ b/apps/auth/src/app/sign-out/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 import { headers } from 'next/headers'
 import { auth, validateRedirectUri } from '@/lib/auth/auth'
+import { captureAuthEvent } from '@/lib/analytics'
 
 interface SignOutPageProps {
   searchParams: Promise<{ redirect_uri?: string }>
@@ -9,6 +10,23 @@ interface SignOutPageProps {
 export default async function SignOutPage({ searchParams }: SignOutPageProps) {
   const { redirect_uri } = await searchParams
   const defaultRedirect = process.env.DEFAULT_REDIRECT_URL || 'http://localhost:3000'
+
+  // Read the session before destroying it — afterwards there is no user id to
+  // attribute the event to. This page is the real sign-out path: consumer apps
+  // redirect here to clear the auth service session, so instrumenting it covers
+  // all of them.
+  try {
+    const session = await auth.api.getSession({ headers: await headers() })
+
+    if (session?.user?.id) {
+      captureAuthEvent({
+        distinctId: session.user.id,
+        event: 'sign_out_completed',
+      })
+    }
+  } catch {
+    // Analytics must never block signing out.
+  }
 
   // Sign out the user (clears the auth service session cookie)
   try {

--- a/apps/auth/src/lib/analytics/__test__/config.test.ts
+++ b/apps/auth/src/lib/analytics/__test__/config.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldCaptureAuthAnalytics } from '../config'
+
+const TOKEN = 'phc_test_token'
+const PRODUCTION_URL = 'https://auth.downbeatacademy.services'
+
+describe('shouldCaptureAuthAnalytics', () => {
+	it('captures when running as the production auth service', () => {
+		expect(
+			shouldCaptureAuthAnalytics({
+				authServiceUrl: PRODUCTION_URL,
+				token: TOKEN,
+			})
+		).toBe(true)
+	})
+
+	it('does not capture without a token', () => {
+		expect(
+			shouldCaptureAuthAnalytics({
+				authServiceUrl: PRODUCTION_URL,
+				token: undefined,
+			})
+		).toBe(false)
+	})
+
+	it('does not capture from localhost', () => {
+		expect(
+			shouldCaptureAuthAnalytics({
+				authServiceUrl: 'http://localhost:3002',
+				token: TOKEN,
+			})
+		).toBe(false)
+	})
+
+	it('does not capture from a preview deploy', () => {
+		// Gated on the service URL rather than NODE_ENV precisely because a
+		// preview deploy also runs with NODE_ENV=production.
+		expect(
+			shouldCaptureAuthAnalytics({
+				authServiceUrl: 'https://auth-pr-42.up.railway.app',
+				token: TOKEN,
+			})
+		).toBe(false)
+	})
+
+	it('does not capture from a lookalike host', () => {
+		expect(
+			shouldCaptureAuthAnalytics({
+				authServiceUrl: 'https://auth.downbeatacademy.services.evil.example',
+				token: TOKEN,
+			})
+		).toBe(false)
+	})
+
+	it('does not throw on a malformed service URL', () => {
+		// This runs during auth initialisation — throwing here would take down
+		// sign-in for everyone over an analytics config problem.
+		expect(() =>
+			shouldCaptureAuthAnalytics({
+				authServiceUrl: 'not a url',
+				token: TOKEN,
+			})
+		).not.toThrow()
+
+		expect(
+			shouldCaptureAuthAnalytics({ authServiceUrl: 'not a url', token: TOKEN })
+		).toBe(false)
+	})
+
+	it('does not capture when the service URL is unset', () => {
+		expect(
+			shouldCaptureAuthAnalytics({ authServiceUrl: undefined, token: TOKEN })
+		).toBe(false)
+	})
+
+	it('captures anywhere when the debug escape hatch is on', () => {
+		expect(
+			shouldCaptureAuthAnalytics({
+				authServiceUrl: 'http://localhost:3002',
+				token: TOKEN,
+				forceEnable: true,
+			})
+		).toBe(true)
+	})
+})

--- a/apps/auth/src/lib/analytics/__test__/resolve-auth-method.test.ts
+++ b/apps/auth/src/lib/analytics/__test__/resolve-auth-method.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveAuthMethod } from '../resolve-auth-method'
+
+describe('resolveAuthMethod', () => {
+	it('resolves the OAuth callback paths', () => {
+		expect(resolveAuthMethod('/callback/google')).toBe('oauth')
+		expect(resolveAuthMethod('/oauth2/callback/github')).toBe('oauth')
+	})
+
+	it('resolves the email paths', () => {
+		expect(resolveAuthMethod('/sign-in/email')).toBe('email')
+		expect(resolveAuthMethod('/sign-up/email')).toBe('email')
+	})
+
+	it('returns null for anything that is not a sign-in entry point', () => {
+		// This is what keeps session refreshes out of the sign-in count. A
+		// session row is created for reasons other than someone signing in, and
+		// reporting those as sign-ins would silently inflate the funnel.
+		expect(resolveAuthMethod('/get-session')).toBeNull()
+		expect(resolveAuthMethod('/update-user')).toBeNull()
+		expect(resolveAuthMethod('/token')).toBeNull()
+	})
+
+	it('returns null when there is no path', () => {
+		expect(resolveAuthMethod(undefined)).toBeNull()
+		expect(resolveAuthMethod('')).toBeNull()
+	})
+
+	it('does not treat a lookalike path as a callback', () => {
+		expect(resolveAuthMethod('/not-a/callback/google')).toBeNull()
+		expect(resolveAuthMethod('/sign-in/email-otp')).toBeNull()
+	})
+})

--- a/apps/auth/src/lib/analytics/config.ts
+++ b/apps/auth/src/lib/analytics/config.ts
@@ -1,0 +1,42 @@
+/**
+ * Hosts the auth service is allowed to report analytics from.
+ *
+ * The same principle as `POSTHOG_ALLOWED_HOSTS` in `apps/www`: without a gate,
+ * local development and every preview deploy write into the production PostHog
+ * project, and there is no way to tell real sign-ins from your own.
+ *
+ * Gated on the service's own configured URL rather than `NODE_ENV`, because a
+ * preview deploy also runs with `NODE_ENV=production`.
+ */
+export const POSTHOG_ALLOWED_AUTH_HOSTS = ['auth.downbeatacademy.services']
+
+export type AuthAnalyticsGateInput = {
+	/** `AUTH_SERVICE_URL` — the origin this service believes it is serving. */
+	authServiceUrl: string | undefined
+	/** `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`. */
+	token: string | undefined
+	/**
+	 * Escape hatch for verifying instrumentation locally, via
+	 * `POSTHOG_DEBUG=true`. Events land in the production project.
+	 */
+	forceEnable?: boolean
+}
+
+export function shouldCaptureAuthAnalytics({
+	authServiceUrl,
+	token,
+	forceEnable = false,
+}: AuthAnalyticsGateInput): boolean {
+	if (!token) return false
+	if (forceEnable) return true
+	if (!authServiceUrl) return false
+
+	try {
+		const { hostname } = new URL(authServiceUrl)
+		return POSTHOG_ALLOWED_AUTH_HOSTS.includes(hostname)
+	} catch {
+		// A malformed AUTH_SERVICE_URL should not capture, and should not throw
+		// during auth initialisation either.
+		return false
+	}
+}

--- a/apps/auth/src/lib/analytics/index.ts
+++ b/apps/auth/src/lib/analytics/index.ts
@@ -1,0 +1,7 @@
+export { captureAuthEvent } from './posthog-server'
+export { resolveAuthMethod } from './resolve-auth-method'
+export {
+	POSTHOG_ALLOWED_AUTH_HOSTS,
+	shouldCaptureAuthAnalytics,
+} from './config'
+export type { AuthAnalyticsGateInput } from './config'

--- a/apps/auth/src/lib/analytics/posthog-server.ts
+++ b/apps/auth/src/lib/analytics/posthog-server.ts
@@ -1,0 +1,82 @@
+import { PostHog } from 'posthog-node'
+import type { AnalyticsEvent, AnalyticsEventMap } from 'analytics'
+
+import { shouldCaptureAuthAnalytics } from './config'
+
+/**
+ * `undefined` = not yet resolved, `null` = deliberately disabled. Distinguishing
+ * the two keeps the gate from being re-evaluated on every event.
+ */
+let client: PostHog | null | undefined
+
+function getClient(): PostHog | null {
+	if (client !== undefined) return client
+
+	const token = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+
+	if (
+		!shouldCaptureAuthAnalytics({
+			authServiceUrl: process.env.AUTH_SERVICE_URL,
+			token,
+			forceEnable: process.env.POSTHOG_DEBUG === 'true',
+		})
+	) {
+		client = null
+		return null
+	}
+
+	// A singleton, unlike `www`'s old per-call construction: this is a
+	// long-running Node server on Railway, not a serverless function.
+	// `flushAt: 1` sends each event immediately, so no shutdown hook is needed
+	// to avoid losing them.
+	client = new PostHog(token as string, {
+		host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com',
+		flushAt: 1,
+		flushInterval: 0,
+	})
+
+	return client
+}
+
+type CaptureInput<E extends AnalyticsEvent> = [AnalyticsEventMap[E]] extends [
+	never,
+]
+	? { distinctId: string; event: E; properties?: undefined }
+	: { distinctId: string; event: E; properties: AnalyticsEventMap[E] }
+
+/**
+ * Captures an auth-funnel event.
+ *
+ * `distinctId` must be the better-auth `user.id`. That is the same id
+ * `apps/www` identifies with, and it is the only thing tying the two together:
+ * they sit on different domains (`downbeatacademy.com` and
+ * `auth.downbeatacademy.services`), so there is no shared cookie and no common
+ * anonymous id.
+ *
+ * Deliberately **not** awaited by callers and never throws. This runs inside
+ * better-auth hooks on the critical path of signing in — analytics failing must
+ * never fail an authentication.
+ */
+export function captureAuthEvent<E extends AnalyticsEvent>({
+	distinctId,
+	event,
+	properties,
+}: CaptureInput<E>): void {
+	const posthog = getClient()
+	if (!posthog) return
+
+	try {
+		posthog.capture({
+			distinctId,
+			event,
+			properties: properties as Record<string, unknown> | undefined,
+		})
+	} catch {
+		// Never let analytics break authentication.
+	}
+}
+
+/** Test seam — forces the gate to be re-evaluated on the next capture. */
+export function resetPostHogClientForTests(): void {
+	client = undefined
+}

--- a/apps/auth/src/lib/analytics/resolve-auth-method.ts
+++ b/apps/auth/src/lib/analytics/resolve-auth-method.ts
@@ -1,0 +1,26 @@
+import type { AuthMethod } from 'analytics'
+
+/**
+ * Works out whether a request authenticated via OAuth or email/password, from
+ * the better-auth endpoint path that handled it.
+ *
+ * The path is the only signal available inside a database hook. This mirrors
+ * the resolution better-auth's own `last-login-method` plugin performs, kept
+ * to the two methods this service actually supports.
+ *
+ * Returns `null` when the path is not a recognised authentication entry point —
+ * a session created by some other route should not be reported as either.
+ */
+export function resolveAuthMethod(path: string | undefined): AuthMethod | null {
+	if (!path) return null
+
+	if (path.startsWith('/callback/') || path.startsWith('/oauth2/callback/')) {
+		return 'oauth'
+	}
+
+	if (path === '/sign-in/email' || path === '/sign-up/email') {
+		return 'email'
+	}
+
+	return null
+}

--- a/apps/auth/src/lib/auth/auth.ts
+++ b/apps/auth/src/lib/auth/auth.ts
@@ -17,6 +17,8 @@ import {
 // Email templates from shared package
 import { VerifyEmail, ResetPasswordEmail } from 'email/emails/index'
 
+import { captureAuthEvent, resolveAuthMethod } from '@/lib/analytics'
+
 // Security: Validate redirect URIs to prevent open redirect attacks
 const TRUSTED_DOMAINS = [
 	'downbeatacademy.com',
@@ -87,6 +89,50 @@ export function createAuth() {
 			schema: authSchema,
 		}),
 
+		// Analytics for the authentication funnel.
+		//
+		// These hooks are the reason the funnel is measurable at all: sign-in
+		// happens here, in the OAuth provider, not in the consumer apps. The
+		// previous instrumentation lived in `apps/www` on its disabled
+		// email-auth path and never fired once.
+		//
+		// Hooking the database rather than the route handlers means every entry
+		// point is covered — email and OAuth alike — without having to find and
+		// annotate each one.
+		databaseHooks: {
+			user: {
+				create: {
+					async after(user, context) {
+						captureAuthEvent({
+							distinctId: user.id,
+							event: 'sign_up_completed',
+							properties: {
+								method: resolveAuthMethod(context?.path) ?? 'email',
+							},
+						})
+					},
+				},
+			},
+			session: {
+				create: {
+					async after(session, context) {
+						const method = resolveAuthMethod(context?.path)
+
+						// A session created by anything other than a recognised
+						// sign-in entry point is not a sign-in — session refreshes
+						// would otherwise inflate the count.
+						if (!method) return
+
+						captureAuthEvent({
+							distinctId: session.userId,
+							event: 'sign_in_completed',
+							properties: { method },
+						})
+					},
+				},
+			},
+		},
+
 		emailAndPassword: {
 			enabled: true,
 			autoSignIn: true,
@@ -94,6 +140,11 @@ export function createAuth() {
 			resetPasswordPath: '/update-password',
 			forgetPasswordPath: '/api/auth/forget-password',
 			sendResetPassword: async ({ user, url, token }, request) => {
+				captureAuthEvent({
+					distinctId: user.id,
+					event: 'password_reset_requested',
+				})
+
 				try {
 					const resend = new Resend(process.env.RESEND_API_KEY)
 					const baseUrl = authServiceUrl.replace(/\/$/, '')

--- a/apps/auth/vitest.config.ts
+++ b/apps/auth/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+	plugins: [tsconfigPaths()],
+	test: {
+		globals: true,
+		// Node, not jsdom: everything tested here runs server-side.
+		environment: 'node',
+		include: ['src/**/__test__/**/*.test.ts'],
+	},
+})

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -114,6 +114,7 @@ repo; see [`../adr/0002-known-gaps.md`](../adr/0002-known-gaps.md).
 | --- | --- | --- |
 | **Sentry** | `apps/www` | `withSentryConfig` in `next.config.js` (org `hype-creative-studios`, project `downbeatacademy`); `instrumentation.ts` lazily loads `sentry.server.config.ts` / `sentry.edge.config.ts`; `onRequestError` ignores stale Server Action IDs and aborted requests |
 | **PostHog** | `apps/www` | Client init in `instrumentation-client.ts` with `api_host: '/ingest'`, reverse-proxied by a `rewrites()` rule to `us.i.posthog.com` to survive ad blockers. Gated by `shouldInitPostHog` in `src/lib/posthog/config.ts`. Events go through the typed `capture` wrapper in `src/lib/posthog/capture.ts`. Identification in `src/components/posthog-identify/` |
+| **PostHog** | `apps/auth` | Server-side only (`posthog-node`), no client init. The authentication funnel: `sign_up_completed` / `sign_in_completed` via better-auth `databaseHooks`, `sign_out_completed` in `src/app/sign-out/page.tsx`, `password_reset_requested` in `sendResetPassword`. Gated by `shouldCaptureAuthAnalytics` on `AUTH_SERVICE_URL` |
 | **Fathom** | `apps/www` | `src/lib/fathom.tsx`, `includedDomains` restricted to `downbeatacademy.com` |
 | **Resend** | `apps/auth`, `apps/www` | `auth` sends verification and reset mail using the `email` package's templates. `www` has its own templates in `src/actions/email/` and does **not** depend on the `email` package |
 
@@ -142,6 +143,13 @@ which is easy to miss when debugging one of them.
 - **A `capture` call that typechecks is not a capture that fires.** Four events in the original
   wizard integration sat on the dead email-auth path and never once ran. Reachability is proven
   by the Cypress `/ingest` spec, not by the type system.
+- **`apps/auth` deliberately has no client-side PostHog.** It is on
+  `auth.downbeatacademy.services` while `www` is on `downbeatacademy.com` — different domains,
+  so a browser SDK there would create a second anonymous-identity pool with nothing to stitch it
+  to the first. Cross-subdomain cookies are not an option either; see
+  [`auth.md`](./auth.md). Capturing server-side against the better-auth `user.id` — the same id
+  `www` identifies with — sidesteps the problem. The cost is that anonymous pre-auth steps on the
+  auth domain are invisible, so drop-off *within* the sign-in page is not measurable.
 
 ## CI
 

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -17,6 +17,14 @@
  *   joining back to Sanity.
  * - Do not add a `$`-prefixed name. Those are PostHog's own (`$pageview`,
  *   `$autocapture`) and are captured by the SDK, not by us.
+ *
+ * ## Every event here must be captured somewhere
+ *
+ * This is a registry of what *is* instrumented, not a wishlist. An event
+ * declared but never captured is indistinguishable, in a PostHog dashboard,
+ * from an event that is broken — which is exactly how four dead events in the
+ * original integration went unnoticed. Add the name when you add the call site,
+ * not before.
  */
 
 /** How a user authenticated. */
@@ -37,9 +45,6 @@ export interface AnalyticsEventMap {
 	sign_in_completed: { method: AuthMethod }
 	sign_out_completed: never
 	password_reset_requested: never
-	password_reset_completed: never
-	/** Which downstream app the user authorised through the OAuth provider. */
-	oauth_authorization_granted: { client_id: string }
 
 	// --- Conversion ----------------------------------------------------------
 	contact_form_submitted: never
@@ -92,8 +97,6 @@ export const ANALYTICS_EVENT_NAMES = [
 	'sign_in_completed',
 	'sign_out_completed',
 	'password_reset_requested',
-	'password_reset_completed',
-	'oauth_authorization_granted',
 	'contact_form_submitted',
 	'newsletter_subscribed',
 	'newsletter_unsubscribed',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
     dependencies:
       '@better-auth/oauth-provider':
         specifier: ^1.6.25
-        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.1)(kysely@0.29.4)(pg@8.22.0)(postgres@3.4.9))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.99.0))(pg@8.22.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@25.7.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))
+        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.1)(kysely@0.29.4)(pg@8.22.0)(postgres@3.4.9))(next@16.2.12(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.99.0))(pg@8.22.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@25.7.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.75.0(react@19.2.8))
@@ -32,6 +32,9 @@ importers:
       '@radix-ui/react-toast':
         specifier: ^1.2.15
         version: 1.2.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      analytics:
+        specifier: workspace:^
+        version: link:../../packages/analytics
       auth-permissions:
         specifier: workspace:^
         version: link:../../packages/auth-permissions
@@ -62,6 +65,9 @@ importers:
       pg:
         specifier: ^8.22.0
         version: 8.22.0
+      posthog-node:
+        specifier: ^5.46.1
+        version: 5.48.0(rxjs@7.8.2)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -107,13 +113,19 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.2.12
-        version: 16.2.12(@typescript-eslint/parser@8.66.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.12(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       start-server-and-test:
         specifier: ^2.1.5
         version: 2.1.5
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vite-tsconfig-paths:
+        specifier: ^6.0.5
+        version: 6.1.1(typescript@5.9.3)(vite@8.2.0(@types/node@25.7.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0))
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@25.7.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0))
 
   apps/cadence-links:
     dependencies:
@@ -192,7 +204,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.2.12
-        version: 16.2.12(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.12(@typescript-eslint/parser@8.66.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -4163,8 +4175,14 @@ packages:
   '@posthog/core@1.45.1':
     resolution: {integrity: sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA==}
 
+  '@posthog/core@1.46.8':
+    resolution: {integrity: sha512-WQTSwlFhsWk09xngTimHiTyhFU8QZHFZEGSm+6brY3acwYdvTLcTxpIhgl/qOCgn/XoqlCFTZqU1ldWLxNntfA==}
+
   '@posthog/types@1.398.0':
     resolution: {integrity: sha512-sJMkl4k+u8yS/0fjHsKqE9xTdsAh30a2WvgChiptellnVoE0e8QJKFgqOMD2sk8FaEArPdeFklAhXvmENAt3Sg==}
+
+  '@posthog/types@1.402.1':
+    resolution: {integrity: sha512-4PZ9wMYI8m8AqJuZ9YR1IAHGVtSnYbBVBgTevrKpzZbcSe/OUwhEV2Ks//rJh/L8eMTU8R5DrD4D/hlrOwaAiQ==}
 
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
@@ -11284,6 +11302,15 @@ packages:
   posthog-js@1.407.2:
     resolution: {integrity: sha512-5deTvXopn+NJWEmCUw8Ix/ms3cv2+60WJ73Vgbvu2wSkZY/FIj2uqAgCnq7IewGpGC+tH7CAbPYFzH6hw8eW1w==}
 
+  posthog-node@5.48.0:
+    resolution: {integrity: sha512-YIH82XV24aa1nnVph1ndiW/vBN2QDIKlrHNEJcmAYutMGeoGC4WeEefg7O5aD3dDcO5dzociy8sVwXq4tNDYsQ==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -14561,12 +14588,12 @@ snapshots:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.4)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.1)(kysely@0.29.4)(pg@8.22.0)(postgres@3.4.9))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.99.0))(pg@8.22.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@25.7.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))':
+  '@better-auth/oauth-provider@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.1)(kysely@0.29.4)(pg@8.22.0)(postgres@3.4.9))(next@16.2.12(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.99.0))(pg@8.22.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@25.7.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.4)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.1)(kysely@0.29.4)(pg@8.22.0)(postgres@3.4.9))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.99.0))(pg@8.22.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@25.7.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0)))
+      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.1)(kysely@0.29.4)(pg@8.22.0)(postgres@3.4.9))(next@16.2.12(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.99.0))(pg@8.22.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@25.7.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0)))
       better-call: 1.3.7(zod@4.4.3)
       jose: 6.2.8
       zod: 4.4.3
@@ -17271,7 +17298,13 @@ snapshots:
     dependencies:
       '@posthog/types': 1.398.0
 
+  '@posthog/core@1.46.8':
+    dependencies:
+      '@posthog/types': 1.402.1
+
   '@posthog/types@1.398.0': {}
+
+  '@posthog/types@1.402.1': {}
 
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -25692,6 +25725,12 @@ snapshots:
     transitivePeerDependencies:
       - preact-render-to-string
 
+  posthog-node@5.48.0(rxjs@7.8.2):
+    dependencies:
+      '@posthog/core': 1.46.8
+    optionalDependencies:
+      rxjs: 7.8.2
+
   powershell-utils@0.1.0: {}
 
   preact@10.29.7: {}
@@ -28170,6 +28209,16 @@ snapshots:
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.9.3)
       vite: 8.0.12(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.2.0(@types/node@25.7.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0)):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      globrex: 0.1.2
+      tsconfck: 3.1.5(typescript@5.9.3)
+      vite: 8.2.0(@types/node@25.7.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
Stacked on #283. Notion: [🧪 Test PostHog Events](https://app.notion.com/p/3b331f290eb3805a8a63ce1a3a1fdba0)

Fourth of five. This closes the biggest remaining hole: **the authentication funnel was completely unmeasured.**

Sign-in happens here, in the OAuth provider — `apps/www` only ever receives the resulting session. The wizard put `user_signed_in` / `user_signed_up` in `www`, on its disabled email-auth path, where they never fired once. #282 removed them; this re-instruments them where the events actually happen.

## Why server-side only, no client init

`apps/auth` is on `auth.downbeatacademy.services`; `www` is on `downbeatacademy.com`. Different domains — so a browser SDK here would mint a *second* anonymous-identity pool with nothing tying it to the first. Cross-subdomain cookies are ruled out by the auth architecture (`apps/www/AGENTS.md:135`).

Capturing server-side against the better-auth `user.id` — the same id `www` already calls `identify()` with — sidesteps that completely. No rewrites, no proxy exclusion, no new client bundle.

**The accepted cost:** anonymous pre-auth steps on the auth domain are invisible, so drop-off *within* the sign-in page is not measurable. Completion rates still are. Making that visible later means adding a client init and accepting the second identity pool — a separate decision.

## What's captured

| Event | Where | Why there |
| --- | --- | --- |
| `sign_up_completed` | `databaseHooks.user.create.after` | Covers every entry point at once |
| `sign_in_completed` | `databaseHooks.session.create.after` | Same — email and OAuth alike |
| `sign_out_completed` | `src/app/sign-out/page.tsx` | The real sign-out path; consumer apps redirect here |
| `password_reset_requested` | `sendResetPassword` | Where the reset actually gets sent |

Hooking the **database** rather than route handlers is the point: there is nothing to remember when a new sign-in method is added.

## The guard worth reviewing closely

`session.create` fires for reasons other than someone signing in. `resolveAuthMethod` returns `null` for any path that is not a recognised sign-in entry point, and the hook bails on `null`. **Remove that guard and session refreshes silently inflate the sign-in count** — a wrong number is worse than no number. There is a test for it.

The path-matching mirrors what better-auth's own `last-login-method` plugin does, narrowed to the two methods this service supports.

## Safety

`captureAuthEvent` never throws and is never awaited. It runs on the critical path of signing in; analytics must not be able to fail an authentication. The client is a module-level singleton — this is a long-running Node server on Railway, not a serverless function — with `flushAt: 1` so no shutdown hook is needed.

Gating is by host, like `www`: `AUTH_SERVICE_URL` must be the production auth service. `NODE_ENV` would not work, because preview deploys also run with `NODE_ENV=production`.

## Also

**`apps/auth` had no unit tests at all** — only the five Cypress specs. It now has a `test` script (vitest, node environment) and 13 tests. `pnpm verify` goes from 23 to 24 tasks.

**Two events removed from the taxonomy.** `password_reset_completed` and `oauth_authorization_granted` were declared in #282 but I could not wire them without guessing at better-auth plugin internals. A declared-but-uncaptured event is indistinguishable from a broken one in a dashboard — which is the exact failure this whole effort exists to fix — so they are gone until something actually fires them. The taxonomy now holds the invariant that every event in it is captured somewhere, and `packages/analytics` documents that.

## Verification

`pnpm verify` passes — 24/24. Note that the `databaseHooks` wiring itself is not unit-tested; it needs a real better-auth instance and a database. Proving those two events fire is the job of the live-event QA pass in the final PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)