### PR TITLE
docs(adr): record the browser support floor and dropdown-menu's retention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,14 @@ labels in a settings panel is a bug.
 - A new component is invisible to consumers until it is re-exported from
   `packages/cadence-core/src/index.ts` — both the component *and* its `*Props` type.
 
+### Browser support
+
+- The floor is **Baseline Newly Available**. A feature at that level may be used directly.
+- Anything below the floor is an enhancement over a working fallback, never the mechanism
+  a component depends on to function. Say what happens without it.
+- Nothing enforces this yet — there is no `browserslist` config. See
+  [`docs/adr/0003-browser-support-floor.md`](./docs/adr/0003-browser-support-floor.md).
+
 ### TypeScript
 
 - `apps/www` and `apps/auth` are `strict: false`; `cadence-links`, `cadence-core`, and

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ These documents explain *why* things are the way they are.
 | --- | --- |
 | [`adr/0001-record-architecture-decisions.md`](./adr/0001-record-architecture-decisions.md) | Why this repo keeps ADRs, and the format |
 | [`adr/0002-known-gaps.md`](./adr/0002-known-gaps.md) | **The known-gaps register.** Read before "fixing" anything that looks broken |
+| [`adr/0003-browser-support-floor.md`](./adr/0003-browser-support-floor.md) | Baseline Newly Available, with progressive enhancement below it |
 
 ## Workflows
 

--- a/docs/adr/0002-known-gaps.md
+++ b/docs/adr/0002-known-gaps.md
@@ -224,10 +224,41 @@ not marked `private`, and changesets bumps their versions, but `release.yml` pas
 and coordination. Recorded only so nobody "fixes" it by wiring up a publish step that
 was never wanted.
 
+### `dropdown-menu` stays on Radix while everything else leaves
+
+**What.** `cadence-core` is removing Radix from 9 of its 12 wrapping components.
+`packages/cadence-core/src/components/dropdown-menu/` is deliberately excluded and keeps
+`@radix-ui/react-dropdown-menu`. As that work lands, the package will look half-migrated:
+most components on the platform, one still wrapping a dependency.
+
+**Why it is fine.** A menu needs typeahead, submenu safe-triangle tracking, roving focus,
+and collision-aware positioning. That is an estimated 5–8 days with real accessibility
+risk, and this repo has one maintainer. The `RadioCardItem` entry above is what happens
+when interaction semantics get hand-rolled here without that budget.
+
+The cost is honest and was accepted: because `react-menu` depends on popper, roving-focus,
+collection, dismissable-layer, focus-scope, portal, and presence, retaining this one
+package retains roughly 25 of the ~38 transitive `@radix-ui/*` packages. Most of the
+dependency-count win is deferred with it. This is a trade of dependency hygiene against
+accessibility risk, not an oversight.
+
+**Recorded so nobody finishes the job unprompted.** An agent seeing eleven components
+migrated and one not will try to close the gap.
+
+**To fix.** Only after native positioning has proven itself in `Tooltip`. Tracked as
+`Radix C.4 — Re-decide whether to rebuild DropdownMenu` on the Remove Radix Dependencies
+epic. Deleting this entry requires that re-decision, not just an implementation.
+
+Relatedly: consolidating the remaining Radix packages onto the single `radix-ui` package
+was considered and **rejected** — it declares all 56 primitives, which enlarges the
+installed set rather than shrinking it, and `.github/dependabot.yml` already batches
+`@radix-ui/*` updates into one PR.
+
 ---
 
 ## Related
 
 - [`0001-record-architecture-decisions.md`](./0001-record-architecture-decisions.md)
+- [`0003-browser-support-floor.md`](./0003-browser-support-floor.md)
 - [`../architecture/monorepo.md`](../architecture/monorepo.md)
 - [`../../AGENTS.md`](../../AGENTS.md)

--- a/docs/adr/0003-browser-support-floor.md
+++ b/docs/adr/0003-browser-support-floor.md
@@ -1,0 +1,78 @@
+# 3. Browser support floor
+
+**Status:** Accepted
+**Date:** 2026-08-05
+
+## Context
+
+This repository has never stated which browsers it supports. There is no
+`.browserslistrc`, no `browserslist` key in any `package.json`, and no prose statement in
+any `AGENTS.md` or architecture document. Every tool falls back to its own default —
+Next.js, esbuild, and the `cadence-core` Rollup build each pick a target independently,
+and nobody chose any of them.
+
+That was tolerable while the design system leaned on a dependency for anything difficult.
+It stopped being tolerable when we started removing those dependencies. Deciding whether
+`cadence-core` may use CSS anchor positioning, the Popover API, `@starting-style`, or
+native `<dialog>` is not answerable without a floor, and the answer changes what the
+design system is allowed to build.
+
+The immediate forcing function was the Radix removal work, but the policy is not about
+Radix. It governs every platform feature anyone reaches for from here on.
+
+Two options were real:
+
+**Baseline Widely Available** — a feature qualifies 30 months after it lands in all major
+engines. Conservative, and it would have blocked native overlay positioning entirely,
+which means keeping a dependency to do the same job.
+
+**Baseline Newly Available** — a feature qualifies once it is in all major engines. Faster
+to adopt, at the cost of an installed-base tail on older versions of those engines.
+
+## Decision
+
+**Target Baseline Newly Available, and use progressive enhancement for anything above the
+floor.**
+
+A feature at Newly Available may be used directly. A feature below it may be used only as
+an enhancement over a working fallback — never as the mechanism the component depends on
+to function.
+
+Concretely, for the work this unblocked: CSS anchor positioning reached Baseline in
+January 2026 when Firefox 147 shipped it, so it may be used. `@position-try` may not be
+relied on — Safari 18.2 and 18.3 support `anchor()` without it — so viewport flipping
+degrades to a static fallback placement rather than breaking. An overlay that cannot flip
+is acceptable. An overlay that renders in the wrong place is not.
+
+Nothing enforces this yet. `browserslist@4.28.2` is already in the lockfile and does
+support a literal `baseline newly available` query, so the floor can be encoded rather
+than only described. That is deliberately left as follow-up work: adding the key changes
+compilation targets across every app and package, which is a behaviour change needing its
+own verification, not a line smuggled into a documentation change.
+
+## Consequences
+
+The design system can own behaviour it previously delegated. Native `<dialog>` with
+`showModal()` replaces a portal, an overlay, a focus scope, and presence tracking in one
+move. Native form controls replace hand-rolled ARIA. This is what makes dependency removal
+worth doing rather than merely a lateral trade.
+
+It also means accepting real users on older engines get a degraded experience, and that
+"degraded" has to be defined per feature rather than assumed. Every use of a
+below-the-floor feature now carries an obligation to say what happens without it. That
+obligation is easy to skip and will need catching in review.
+
+Newly Available moves. A feature qualifying today did not six months ago, so this record
+states a policy, not a fixed list. Re-read it against
+[caniuse](https://caniuse.com/) and [Baseline](https://web.dev/baseline) at the time of
+use rather than trusting the examples above, which are accurate as of the date on this
+record and will age.
+
+Until the `browserslist` key exists, this is a convention enforced by reading. That is
+weaker than a config, and is the main reason to finish the follow-up.
+
+## Related
+
+- [`0001-record-architecture-decisions.md`](./0001-record-architecture-decisions.md)
+- [`0002-known-gaps.md`](./0002-known-gaps.md) — records `dropdown-menu`'s deliberate
+  retention on Radix


### PR DESCRIPTION
Closes the open question on the [🏗️ Remove Radix Dependencies](https://app.notion.com/p/3b331f290eb380f69e3fd78296b89216) epic: *"Is a repository ADR wanted to record the dependency decision and browser-support floor, so the choice survives outside Notion?"*

Answered as a split rather than yes/no, because the question bundled two decisions with different cases.

## ADR 0003 — browser support floor

The repo has never stated which browsers it supports. No `.browserslistrc`, no `browserslist` key in any `package.json`, no prose in any `AGENTS.md` or architecture doc. Next.js, esbuild, and the `cadence-core` Rollup build each pick a target independently and nobody chose any of them.

That became load-bearing when `cadence-core` started replacing dependencies with platform features — whether a component may use CSS anchor positioning, the Popover API, or native `<dialog>` is not answerable without a floor.

**Decision: Baseline Newly Available, with progressive enhancement below it.** A feature at that level may be used directly; anything below may only enhance a working fallback. The concrete case: `anchor()` is usable, `@position-try` is not relied on (Safari 18.2–18.3 support the former without the latter), so viewport flipping degrades to a static placement.

The Radix work forced the question, but the policy governs every platform feature from here on. Filing it under an epic that will eventually be archived would lose it.

## Known-gaps entry — `dropdown-menu` stays on Radix

Added to `0002`, under low severity, in the same "recorded so nobody 'fixes' it" shape as the versioned-but-never-published entry.

Once Phases A and B land, `cadence-core` looks half-migrated: eleven components on the platform, one still wrapping a dependency. An agent will try to close that gap. The entry states the reasoning (typeahead, submenu safe-triangle, roving focus, collision-aware positioning — 5–8 days with real accessibility risk for a solo maintainer), the honest cost (~25 of ~38 transitive packages retained with it), and that deleting the entry requires the C.4 re-decision, not just an implementation. It also records the `radix-ui` consolidation rejection.

## Not recorded as an ADR

The tiered sequencing and the 0.2 rejection. Those are roadmap reasoning, Notion holds them, and the code shows the outcome as components migrate — ADR-0001 explicitly excludes routine implementation choices.

## Also

- `docs/README.md` — 0003 added to the decisions table
- `AGENTS.md` — new `### Browser support` subsection under Conventions, since agents read this and the floor constrains what they may reach for

## Verified

- `pnpm verify` — 21/21 (FULL TURBO; no code changed, so this is a formality)
- All relative markdown links in the four touched files resolve to real paths
- Docs-only, so no changeset

## Deliberately not done

`browserslist@4.28.2` is **already in the lockfile** and does support a literal `baseline newly available` query — I verified this in `node_modules` rather than assuming it. So the floor can be enforced in config, not just described in prose. Adding the key changes compilation targets across every app and package, which is a behaviour change needing its own verification and bundle comparison. Recorded as follow-up in the ADR's Decision and Consequences sections; the ADR is explicit that until then this is a convention enforced by reading, which is weaker than a config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)