### PR TITLE
chore(skills): replace the prefer-Radix guidance with a platform-first policy

### DIFF
--- a/.claude/agents/accessibility-engineer.md
+++ b/.claude/agents/accessibility-engineer.md
@@ -18,16 +18,29 @@ than React. ARIA semantics, keyboard interaction, focus order, and contrast are
 framework-independent — only the implementation vehicle differs. Nothing consumes that
 package yet, so treat it as lower priority, not out of scope.
 
-## Prefer Radix, and do not undermine it
+## Prefer the platform, then the APG, then a dependency
 
-Many Cadence components wrap Radix UI primitives — dialog, drawer, dropdown-menu, tabs,
-toast, tooltip, hover-card, switch, checkbox, radio-group, separator, collapsible. Radix
-already implements the keyboard interaction, focus trapping, and ARIA semantics correctly.
+**Reach for the native element first.** Native form controls, `<dialog>` with
+`showModal()`, `<details>`, and the Popover API provide form participation, focus
+trapping, top-layer placement, `::backdrop`, background inerting, arrow-key group
+navigation, and roving tabindex — correctly, in every engine, with no code. The browser
+support floor is Baseline Newly Available with progressive enhancement below it
+(`docs/adr/0003-browser-support-floor.md`), which is what makes this viable for overlays
+and positioning.
 
-**For anything with interaction semantics, wrap the Radix primitive rather than
-reimplementing it.** Reimplementation is where accessibility gets lost.
+Where the platform has no answer, implement the WAI-ARIA APG pattern directly, with tests
+written first. Where neither is safe — menus, with typeahead, submenu safe-triangle
+tracking, and collision-aware positioning — a dependency is the right call.
 
-Just as important: do not defeat the primitive you wrapped. The known defect in this repo
+`cadence-core` is actively migrating off Radix for this reason: several wrappers are
+measurably *worse* than the native element they replace. `Checkbox`, `Radio`, and `Switch`
+render `<button role="checkbox">` with a hidden input bubbled in purely for form
+participation, which native inputs do properly. `dropdown-menu` is the one deliberate
+retention (`docs/adr/0002-known-gaps.md`). **Do not recommend adding a Radix dependency to
+a new component.**
+
+Where a wrapper still exists, do not defeat the primitive underneath it. The known defect
+in this repo
 is exactly that — `packages/cadence-core/src/components/form/radio-card/radio-card-item.tsx`
 renders the Radix `RadioGroup.Item` with `aria-hidden="true"` and `tabIndex={-1}`, and
 moves selection onto a bare `<div onClick>` with no role, no `tabIndex`, and no key

--- a/.claude/agents/cadence-design-system.md
+++ b/.claude/agents/cadence-design-system.md
@@ -60,7 +60,10 @@ before designing in those areas.
 ## Components
 
 27 top-level components in `cadence-core`, folder-per-component with `__test__/` and
-`__docs__/`. Radix primitives are wrapped for anything with interaction semantics.
+`__docs__/`. Twelve currently wrap Radix primitives, and are being migrated off them onto
+native elements — build new interaction on the platform first, and do not add a Radix
+dependency. `dropdown-menu` is the one deliberate retention
+(`docs/adr/0002-known-gaps.md`).
 
 The rules that matter:
 

--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -17,9 +17,25 @@ the authoritative list.
 composition specific to a single app belongs in that app's `src/components/`. If in
 doubt, it belongs here — app-local UI has a habit of being copy-pasted.
 
-**Decide whether to wrap Radix.** Anything with interaction semantics — a menu, dialog,
-popover, disclosure, selection control — should wrap the Radix primitive rather than
-reimplement keyboard and focus behaviour. Many components already do.
+**Decide what implements the interaction.** In order of preference:
+
+1. **The native element, where one exists.** Form controls, `<dialog>` with `showModal()`,
+   `<details>`, the Popover API, CSS anchor positioning. Native gives you form
+   participation, focus trapping, top-layer placement, and keyboard behaviour for free —
+   usually with *less* code than a wrapper, not more.
+2. **Hand-rolled against the WAI-ARIA APG**, for well-specified patterns the platform does
+   not cover — tabs with roving tabindex, for instance. Only with tests written first.
+3. **A dependency**, only for patterns the platform genuinely does not cover and the APG
+   does not make safe to hand-roll. Right now that means menus, with typeahead, submenu
+   safe-triangle tracking, and collision-aware positioning.
+
+The browser-support floor is **Baseline Newly Available**, with progressive enhancement
+below it — see [`docs/adr/0003-browser-support-floor.md`](../../../docs/adr/0003-browser-support-floor.md).
+That is what makes option 1 viable for overlays and positioning.
+
+**Do not add a new Radix dependency.** `cadence-core` is actively removing them; see the
+Remove Radix Dependencies epic. `dropdown-menu` is the one deliberate retention, recorded
+in [`docs/adr/0002-known-gaps.md`](../../../docs/adr/0002-known-gaps.md).
 
 ## Scaffold
 
@@ -36,8 +52,12 @@ packages/cadence-core/src/components/<name>/
 ```
 
 Copy the shape of an existing component of similar complexity. `badge/` is a good simple
-reference; `dialog/` is a good Radix-wrapping reference; `form/radio-card/` is not — it
-has a known accessibility defect.
+reference, and `form/select/` and `summary/` are the references for building on a native
+element — a styled `<select>` and a native `<details>` respectively.
+
+Do **not** copy `form/radio-card/`, which has a known accessibility defect, and do not
+copy the Radix-wrapping components as a pattern — they are what this package is migrating
+away from.
 
 ### `<name>.tsx`
 
@@ -124,6 +144,8 @@ Add <Name> — one line on what it is for.
 
 ## Checklist
 
+- [ ] Built on the native element where one exists; no new Radix dependency
+- [ ] Anything below the browser-support floor degrades to a working fallback
 - [ ] Folder layout complete, including `__test__/` and `__docs__/`
 - [ ] Exported from `src/index.ts` — component **and** `*Props`
 - [ ] Every CSS value is a `--cds-*` token; semantic, not palette

--- a/docs/architecture/design-system.md
+++ b/docs/architecture/design-system.md
@@ -108,8 +108,12 @@ expect(el).toHaveClass(s.root)      // correct
 expect(el).toHaveClass('root')      // wrong — never matches
 ```
 
-Many components wrap Radix UI primitives (dialog, drawer, dropdown-menu, tabs, toast,
-tooltip, hover-card, switch, checkbox, radio-group, separator, collapsible, slot).
+Twelve components currently wrap Radix UI primitives (dialog, drawer, dropdown-menu, tabs,
+toast, tooltip, hover-card, switch, checkbox, radio-group, separator, collapsible, slot),
+and are being migrated onto native elements. New interaction should be built on the
+platform first — see the `new-component` skill for the order of preference, and
+[`../adr/0002-known-gaps.md`](../adr/0002-known-gaps.md) for why `dropdown-menu` keeps its
+dependency.
 `DataTable` wraps `@tanstack/react-table` and supports manual/server-side sorting,
 pagination, and filtering — use it for any list or table view rather than hand-rolling.
 


### PR DESCRIPTION
[Radix 0.5](https://app.notion.com/p/3b431f290eb3810eaaf7d719b5ce04fa) on the [🏗️ Remove Radix Dependencies](https://app.notion.com/p/3b331f290eb380f69e3fd78296b89216) epic. Last of the Phase 0 guidance work; unblocks nothing directly but stops the epic being undone as it runs.

## The problem

`.claude/skills/new-component/SKILL.md` told agents:

> Anything with interaction semantics — a menu, dialog, popover, disclosure, selection control — should wrap the Radix primitive rather than reimplement keyboard and focus behaviour.

That was reasonable when written. It predates both the browser-support floor and the decision to remove Radix from `cadence-core`, so every new component built under it re-adds the dependency the epic is removing.

## The replacement

An explicit order of preference, rather than a single rule:

1. **The native element**, where one exists — form controls, `<dialog>` + `showModal()`, `<details>`, Popover API, anchor positioning
2. **Hand-rolled against the WAI-ARIA APG**, for well-specified patterns the platform misses, with tests written first
3. **A dependency**, only for what neither covers — currently menus (typeahead, submenu safe-triangle, collision-aware positioning)

Anchored to the Baseline Newly Available floor from `docs/adr/0003`, since that is what makes option 1 viable for overlays. Reference components updated too: `form/select/` and `summary/` are now the examples to copy, replacing `dialog/` as "a good Radix-wrapping reference".

## Beyond the task's file list

The task named the skill and `docs/architecture/design-system.md`. Grepping for the guidance found two agent definitions carrying the same instruction, either of which would have defeated this change on its own:

- **`.claude/agents/accessibility-engineer.md`** had a section headed **"Prefer Radix, and do not undermine it"** — the strongest statement of the old policy, in the agent most likely to be asked what a component should be built on. Now leads with the platform, and notes that `Checkbox`/`Radio`/`Switch` are measurably worse than the native inputs they replace.
- **`.claude/agents/cadence-design-system.md`** asserted Radix wrapping as the house pattern.

Both now carry the platform-first order and record `dropdown-menu` as the deliberate retention.

## Deliberately left alone

`packages/cadence-core/docs/README.md` and `docs/setup/development-guide.md` list `@radix-ui/*` under dependencies. Still factually true — twelve are declared — and those lists correct themselves as Phase A and B remove them. Changing them now would make the docs wrong in the other direction.

`apps/www/CHANGELOG.md` mentions a Radix primitive in a past entry. Changelogs are history.

## Verified

- `pnpm verify` — 21/21 (FULL TURBO; no code changed)
- Grepped for remaining "wrap the Radix primitive" / "prefer Radix" guidance: only the new descriptive text and the changelog entry remain
- All relative markdown links in the touched files resolve
- No changeset — `.claude/` and `docs/` are not versioned packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)