### PR TITLE
docs: point agent guidance at the shared test helpers

### DIFF
--- a/.claude/agents/accessibility-engineer.md
+++ b/.claude/agents/accessibility-engineer.md
@@ -86,9 +86,22 @@ await user.keyboard('{ArrowDown}')
 A test that only checks class names cannot catch a missing role — that is precisely how
 the radio-card defect shipped.
 
+**Use the shared helpers in `packages/cadence-core/src/test-utils/`.** `axeViolations()`
+runs axe and returns the violations array — assert `toEqual([])` so a failure names the
+rule and the offending node rather than `expected false to be true`. `declaredRule()` and
+`declaredRules()` read declared CSS rule text. Import by relative path; they are not
+re-exported from the barrel. Interactive components should carry an `-a11y.test.tsx`
+alongside their behaviour suite.
+
 Two jsdom limitations to keep in mind: it performs no layout, so anything geometric must
 be verified in a browser; and it does not resolve `var()`, so `getComputedStyle` on any
 token-driven property returns the CSS initial value. Assert declared rules instead.
+
+**The first limitation has teeth for contrast.** `axeViolations()` disables axe's
+`color-contrast` rule and does not permit re-enabling it — without layout, axe cannot
+resolve computed colors, so the rule reports nothing and yields a false pass. A green
+vitest run says nothing about contrast. **Check it in the Storybook a11y addon panel**,
+which runs in a real browser; the addon is registered in `.storybook/main.ts`.
 
 `apps/www` has `cypress-axe` available for automated auditing in E2E, but automated checks
 catch a minority of real problems. Tab through the component yourself in Storybook

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -46,8 +46,18 @@ for months.
 `borderRadius` reads back as the literal string `"var(--cds-radii-medium)"`. The identical
 rule written with a literal value computes correctly. So **any `getComputedStyle`
 assertion on a token-driven property is vacuous or wrong**. Assert the declared CSS rule
-instead — see the `declaredRootRule()` helper in
-`packages/cadence-core/src/components/sidebar/__test__/sidebar-styles.test.tsx`.
+instead, with `declaredRule()` from `packages/cadence-core/src/test-utils`.
+
+**`cadence-core` has shared test helpers.** `src/test-utils/` holds `axeViolations()`,
+`declaredRule()`, `declaredRules()`, and `formatViolations()`. Import them by relative
+path — they are deliberately not re-exported from `src/index.ts`, and the folder is
+excluded from `tsconfig.json` so nothing reaches `dist/`. Reach for these before writing a
+local `axe.run` wrapper or a private stylesheet walker; both used to exist per-suite.
+
+`axeViolations()` disables axe's `color-contrast` rule and does not let you re-enable it.
+jsdom has no layout engine, so axe cannot resolve computed colors there and the rule can
+only produce a false pass. **Contrast is checked in a real browser** through the Storybook
+a11y addon panel, not in vitest.
 
 **Class names are hashed at build time** into `cds-<component>-<name>--<hash>`. Assert
 against the imported module binding, never a string literal:

--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -97,7 +97,21 @@ consumers**, and the error they see is an unhelpful module resolution failure.
 
 ## Test
 
-vitest + Testing Library, jsdom. Two rules specific to this package:
+vitest + Testing Library, jsdom.
+
+**Use the shared helpers in `src/test-utils/`** rather than writing your own:
+
+| Helper | Use |
+| --- | --- |
+| `axeViolations(container, rules?)` | Runs axe; assert `toEqual([])` so a failure names the rule and node |
+| `declaredRule(className)` | Declared `cssText` for one class |
+| `declaredRules(className)` | Every rule containing the class — `:hover`, `[data-state]`, other modifiers |
+| `formatViolations(violations)` | Readable output when the raw array is too noisy |
+
+Import by relative path (`../../../test-utils`). They are deliberately **not** exported
+from `src/index.ts` — the barrel is the public API.
+
+Two rules specific to this package:
 
 **Class names are hashed at build time.** Assert against the imported module binding:
 
@@ -109,14 +123,18 @@ expect(el).toHaveClass('root')   // never matches
 
 **jsdom does not resolve `var()`.** `getComputedStyle` on any token-driven property
 returns the CSS initial value — `border: 1px solid var(--cds-color-border-faint)` reads
-back as `borderStyle: 'none'`. To assert token-driven styling, inspect the *declared*
-rule; see `src/components/sidebar/__test__/sidebar-styles.test.tsx` for the
-`declaredRootRule()` helper.
+back as `borderStyle: 'none'`. To assert token-driven styling, inspect the *declared* rule
+with `declaredRule(s.root)`. `src/components/sidebar/__test__/sidebar-styles.test.tsx` is
+the worked example.
 
 Cover: renders, variants and sizes apply the right classes, disabled/invalid states,
 `className` passthrough, ref forwarding, and — for anything interactive — **a real
 `getByRole` query and keyboard operation**. That last one is not optional; it is exactly
 what was missing when `radio-card` shipped inaccessible.
+
+For anything interactive, add an `-a11y.test.tsx` alongside it using `axeViolations()`.
+Note that `color-contrast` cannot run under jsdom and is disabled — check contrast in the
+Storybook a11y addon panel instead.
 
 ## Story
 

--- a/docs/architecture/design-system.md
+++ b/docs/architecture/design-system.md
@@ -112,6 +112,12 @@ expect(el).toHaveClass(s.root)      // correct
 expect(el).toHaveClass('root')      // wrong — never matches
 ```
 
+Shared test helpers live in `packages/cadence-core/src/test-utils/` — `axeViolations()`
+for axe runs, `declaredRule()` and `declaredRules()` for asserting token-driven CSS that
+`getComputedStyle` cannot see under jsdom. They are imported by relative path and are
+deliberately absent from the barrel. Storybook carries `@storybook/addon-a11y`, which is
+where `color-contrast` is actually checked — that rule cannot run under jsdom.
+
 Twelve components currently wrap Radix UI primitives (dialog, drawer, dropdown-menu, tabs,
 toast, tooltip, hover-card, switch, checkbox, radio-group, separator, collapsible, slot),
 and are being migrated onto native elements. New interaction should be built on the
@@ -190,6 +196,7 @@ When adding or changing a component:
 - [ ] Semantic color tokens, never palette tokens
 - [ ] Correct type family for the surface
 - [ ] Keyboard accessible and announced correctly — verify with a real role query in the test
+- [ ] Interactive components carry an `-a11y.test.tsx` using `axeViolations()`
 - [ ] `pnpm core:build` and check it in Storybook
 - [ ] Changeset added
 

--- a/packages/cadence-core/docs/setup/development-guide.md
+++ b/packages/cadence-core/docs/setup/development-guide.md
@@ -61,7 +61,7 @@ cadence-core/
 │   └── global.d.ts         # Global type definitions
 ├── docs/                   # Package documentation
 ├── dist/                   # Build output
-├── storybook-static/       # Storybook build output
+├── storybook-static/       # Storybook build output (gitignored; built on Railway)
 ├── package.json
 ├── rollup.config.js        # Build configuration
 ├── vite.config.ts          # Vite/Vitest configuration


### PR DESCRIPTION
Cleanup pass at the end of Phase 0 of the [🏗️ Remove Radix Dependencies](https://app.notion.com/p/3b331f290eb380f69e3fd78296b89216) epic. Mostly fixing my own fallout.

## Broken references

#292 moved the sidebar suite's private `declaredRootRule()` and `findViolations()` into `packages/cadence-core/src/test-utils/`. Two agent-facing documents still pointed at the old location, so anyone — or any agent — following them hit a dead reference:

- `.claude/agents/test-engineer.md`
- `.claude/skills/new-component/SKILL.md`

Both now name `declaredRule()` and its real home.

## Recorded while fixing them

The harness landed in #292 but was only documented in `packages/cadence-core/AGENTS.md`. The docs most likely to be read *before* writing a test didn't mention it:

- **The four helpers**, with the rule that they're imported by relative path and never re-exported from the barrel
- **`axeViolations()` disables `color-contrast` and refuses to re-enable it.** jsdom has no layout engine, so axe cannot resolve computed colors and the rule yields a false pass. **A green vitest run says nothing about contrast** — it's checked in the Storybook a11y addon panel. Stated most forcefully in `accessibility-engineer.md`, where assuming otherwise is most expensive
- **Interactive components carry an `-a11y.test.tsx`** — added to the `design-system.md` checklist
- `storybook-static/` is gitignored and built on Railway, noted in the development guide's directory tree, following #293

## Verified

- `pnpm verify` — 21/21
- Grepped for remaining `declaredRootRule` / `findViolations` references: **none**
- Every path named in the new prose resolves against the tree, and the four helper names match the actual exports in `src/test-utils/`

Docs-only; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)