### PR TITLE
test(cadence-core): backfill separator coverage

### DIFF
--- a/.changeset/separator-test-coverage.md
+++ b/.changeset/separator-test-coverage.md
@@ -1,0 +1,12 @@
+---
+'cadence-core': patch
+---
+
+Adds the first test coverage for `Separator`, which shipped untested. Records the current
+`@radix-ui/react-separator` behavior as a regression contract: `role="none"` by default and
+`role="separator"` when `decorative` is false, `aria-orientation` emitted only for the
+vertical non-decorative case, and `data-orientation` present regardless — the attribute the
+stylesheet keys off. Adds an axe suite covering both roles, both orientations, and the
+in-list position.
+
+Tests only — no component, API, or bundle change.

--- a/packages/cadence-core/src/components/separator/__test__/separator-a11y.test.tsx
+++ b/packages/cadence-core/src/components/separator/__test__/separator-a11y.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { Separator } from '../index'
+import { axeViolations } from '../../../test-utils'
+
+/**
+ * Axe coverage for the current Radix implementation, so the A.1 rewrite has a baseline to
+ * hold. `axeViolations` disables `color-contrast` and does not allow re-enabling it —
+ * jsdom has no layout engine, so that rule can only produce a false pass. The separator's
+ * contrast against its background is checked in the Storybook a11y addon panel instead.
+ */
+
+/**
+ * Separators are only meaningful between things, and axe's rules for `separator` depend on
+ * the surrounding structure — asserting on one rendered alone would exercise almost
+ * nothing.
+ */
+const Between = ({ children }: { children: React.ReactNode }) => (
+	<section aria-label="Account settings">
+		<p>Profile</p>
+		{children}
+		<p>Billing</p>
+	</section>
+)
+
+describe('Separator accessibility', () => {
+	it('has no axe violations when decorative', async () => {
+		const { container } = render(
+			<Between>
+				<Separator />
+			</Between>
+		)
+		expect(await axeViolations(container)).toEqual([])
+	})
+
+	it('has no axe violations when exposed as a separator', async () => {
+		const { container } = render(
+			<Between>
+				<Separator decorative={false} />
+			</Between>
+		)
+		expect(await axeViolations(container)).toEqual([])
+	})
+
+	it('has no axe violations when vertical and exposed', async () => {
+		const { container } = render(
+			<Between>
+				<Separator decorative={false} orientation="vertical" />
+			</Between>
+		)
+		expect(await axeViolations(container)).toEqual([])
+	})
+
+	it('has no axe violations repeated between content blocks', async () => {
+		// The shape both apps/www consumers use — `account/page.tsx` and
+		// `changelog-drawer.tsx` both stack separators between blocks inside a Flex.
+		const entries = ['1.2.0', '1.1.0', '1.0.0']
+		const { container } = render(
+			<section aria-label="Changelog">
+				{entries.map((version, i) => (
+					<React.Fragment key={version}>
+						<p>{version}</p>
+						{i < entries.length - 1 && <Separator />}
+					</React.Fragment>
+				))}
+			</section>
+		)
+		expect(await axeViolations(container)).toEqual([])
+	})
+
+	it('has no axe violations separating items in a list', async () => {
+		// A separator inside a `<ul>` has to sit *within* an `<li>`. Putting the role on
+		// the `<li>` strips its listitem role and axe's `list` rule flags the whole list —
+		// which is why `sidebar-separator.tsx` wraps rather than replaces. Guarded here so
+		// the A.1 rewrite keeps working in that position.
+		const { container } = render(
+			<ul aria-label="Account actions">
+				<li>
+					<a href="#profile">Profile</a>
+				</li>
+				<li>
+					<Separator decorative={false} />
+				</li>
+				<li>
+					<a href="#signout">Sign out</a>
+				</li>
+			</ul>
+		)
+		expect(await axeViolations(container)).toEqual([])
+	})
+})

--- a/packages/cadence-core/src/components/separator/__test__/separator.test.tsx
+++ b/packages/cadence-core/src/components/separator/__test__/separator.test.tsx
@@ -1,0 +1,192 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Separator } from '../index'
+import type { SeparatorColor } from '../types'
+import s from '../separator.module.css'
+import { declaredRules } from '../../../test-utils'
+
+/**
+ * Written against the *current* `@radix-ui/react-separator` behavior, verified by
+ * inspecting the rendered markup rather than by reading Radix's source. These are the
+ * regression contract for Radix 0.3 → A.1: the hand-rolled `<div>` that replaces
+ * `SeparatorPrimitive.Root` has to satisfy every assertion here unchanged.
+ *
+ * What Radix emits today, for the record:
+ *
+ *   <Separator />                              → role="none"      data-orientation="horizontal"
+ *   <Separator decorative={false} />           → role="separator" data-orientation="horizontal"
+ *   <Separator decorative={false} vertical />  → role="separator" data-orientation="vertical"
+ *                                                aria-orientation="vertical"
+ *
+ * The two subtleties worth preserving deliberately: `aria-orientation` is emitted only for
+ * the *vertical, non-decorative* case — `horizontal` is the ARIA default for `separator`
+ * and is left implicit — and `data-orientation` is present regardless of `decorative`,
+ * because it is what the stylesheet keys off.
+ */
+
+const COLORS: SeparatorColor[] = [
+	'primary',
+	'faint',
+	'brand',
+	'interactive',
+	'success',
+	'warning',
+	'critical',
+	'high-contrast',
+]
+
+/** The rendered element is the only child of the render container. */
+const subject = (container: HTMLElement) =>
+	container.firstElementChild as HTMLElement
+
+describe('Separator role semantics', () => {
+	it('is hidden from the accessibility tree by default', () => {
+		// `decorative` defaults to true, so the default separator is presentational. Both
+		// consumers in apps/www rely on this default.
+		const { container } = render(<Separator />)
+		expect(screen.queryByRole('separator')).toBeNull()
+		expect(subject(container)).toHaveAttribute('role', 'none')
+	})
+
+	it('exposes role="separator" when decorative is false', () => {
+		render(<Separator decorative={false} />)
+		expect(screen.getByRole('separator')).toBeInTheDocument()
+	})
+
+	it('is still presentational when decorative and vertical', () => {
+		const { container } = render(<Separator orientation="vertical" />)
+		expect(screen.queryByRole('separator')).toBeNull()
+		expect(subject(container)).toHaveAttribute('role', 'none')
+	})
+})
+
+describe('Separator orientation', () => {
+	it('omits aria-orientation when horizontal, since that is the ARIA default', () => {
+		render(<Separator decorative={false} />)
+		expect(screen.getByRole('separator')).not.toHaveAttribute(
+			'aria-orientation'
+		)
+	})
+
+	it('sets aria-orientation when vertical', () => {
+		render(<Separator decorative={false} orientation="vertical" />)
+		expect(screen.getByRole('separator')).toHaveAttribute(
+			'aria-orientation',
+			'vertical'
+		)
+	})
+
+	it('omits aria-orientation on a decorative vertical separator', () => {
+		// role="none" carries no orientation, so the attribute would be meaningless.
+		const { container } = render(<Separator orientation="vertical" />)
+		expect(subject(container)).not.toHaveAttribute('aria-orientation')
+	})
+
+	it.each(['horizontal', 'vertical'] as const)(
+		'reflects %s in data-orientation regardless of decorative',
+		(orientation) => {
+			// data-orientation is the styling hook (see the stylesheet assertion below), so
+			// it must be emitted even when the separator is presentational.
+			const decorative = render(<Separator orientation={orientation} />)
+			expect(subject(decorative.container)).toHaveAttribute(
+				'data-orientation',
+				orientation
+			)
+
+			const semantic = render(
+				<Separator orientation={orientation} decorative={false} />
+			)
+			expect(subject(semantic.container)).toHaveAttribute(
+				'data-orientation',
+				orientation
+			)
+		}
+	)
+})
+
+describe('Separator styling hooks', () => {
+	it('always applies the root class', () => {
+		const { container } = render(<Separator />)
+		expect(subject(container)).toHaveClass(s.root)
+	})
+
+	it.each(COLORS)('applies the %s color class', (color) => {
+		// Asserted against the imported binding, never a literal — class names are hashed.
+		const { container } = render(<Separator color={color} />)
+		expect(subject(container)).toHaveClass(s[`color--${color}`])
+	})
+
+	it('defaults to the primary color', () => {
+		const { container } = render(<Separator />)
+		expect(subject(container)).toHaveClass(s['color--primary'])
+	})
+
+	it('sizes itself from data-orientation, not from an orientation class', () => {
+		// `separator.tsx` builds a class name `orientation--${orientation}`, but the
+		// stylesheet declares no such rule — the module exports only `root` and the eight
+		// `color--*` keys, so the lookup is `undefined` and `classnames` drops it. The
+		// orientation styling actually comes from `[data-orientation]` attribute selectors.
+		// Pinned here so the A.1 rewrite cannot quietly drop the attribute the CSS needs.
+		expect(s).not.toHaveProperty('orientation--horizontal')
+		expect(s).not.toHaveProperty('orientation--vertical')
+
+		const rules = declaredRules(s.root).join('\n')
+		expect(rules).toMatch(/width:\s*100%/)
+		expect(rules).toMatch(/min-height:\s*100%/)
+	})
+
+	it('merges a consumer className with its own', () => {
+		const { container } = render(<Separator className="custom" />)
+		expect(subject(container)).toHaveClass(
+			'custom',
+			s.root,
+			s['color--primary']
+		)
+	})
+})
+
+describe('Separator element contract', () => {
+	it('renders a div', () => {
+		const { container } = render(<Separator />)
+		expect(subject(container).tagName).toBe('DIV')
+	})
+
+	it('forwards a ref to the underlying element', () => {
+		const ref = React.createRef<HTMLDivElement>()
+		const { container } = render(<Separator ref={ref} />)
+		expect(ref.current).toBeInstanceOf(HTMLDivElement)
+		expect(ref.current).toBe(subject(container))
+	})
+
+	it('passes arbitrary props through to the element', () => {
+		render(<Separator id="rule" data-testid="sep" />)
+		expect(screen.getByTestId('sep')).toHaveAttribute('id', 'rule')
+	})
+})
+
+describe('Separator keyboard behavior', () => {
+	// A separator is non-interactive. "Keyboard operation" here means proving it stays out
+	// of the tab order in both roles — a hand-rolled replacement that adds a tabIndex, or
+	// swaps in a focusable element, would be a regression.
+	it.each([true, false])(
+		'is not focusable and is skipped by Tab (decorative=%s)',
+		async (decorative) => {
+			const user = userEvent.setup()
+			render(
+				<>
+					<button type="button">before</button>
+					<Separator decorative={decorative} data-testid="sep" />
+					<button type="button">after</button>
+				</>
+			)
+			expect(screen.getByTestId('sep')).not.toHaveAttribute('tabindex')
+
+			await user.tab()
+			expect(screen.getByRole('button', { name: 'before' })).toHaveFocus()
+			await user.tab()
+			expect(screen.getByRole('button', { name: 'after' })).toHaveFocus()
+		}
+	)
+})


### PR DESCRIPTION
## What and why

`separator` is one of five components in the package with no `__test__/` directory at all, and Radix 0.3 makes that a hard gate: no Phase A or B rewrite starts before its component has tests. The precedent is `form/radio-card/`, which shipped inaccessible precisely because it was written without them. This is slice 1 of 5 in that backfill, and `separator` is deliberately first — it is the smallest, so it establishes the pattern the other four copy.

**Notion task:** [Radix 0.3 — Backfill tests for dialog, dropdown-menu, separator, tabs, toast](https://app.notion.com/p/3b431f290eb3813eb8a0c56d965b6035) · unblocks [Radix A.1 — Migrate Separator off Radix](https://app.notion.com/p/3b431f290eb381ca9751e816498b8eeb)

Tests only — `separator.tsx` is byte-identical to `main`. The diff is two test files and a changeset.

Assertions are written against **current** `@radix-ui/react-separator` behaviour, verified by inspecting rendered markup rather than reading Radix's source, so they are the regression contract the native replacement has to satisfy unchanged. Three details would otherwise be easy to lose in the rewrite:

- `role="none"` by default (`decorative` defaults to `true`), `role="separator"` only when it is `false`.
- `aria-orientation` emitted **only** for the vertical *and* non-decorative case; `horizontal` is the ARIA default and stays implicit, and a decorative separator carries no orientation at all.
- `data-orientation` emitted regardless of `decorative`, because it is the hook the stylesheet keys off.

"Keyboard operation" for a non-interactive element means proving it stays *out* of the tab order, so that is what those tests assert, in both roles. The axe suite uses the 0.4 harness across both roles, both orientations, the repeated-between-blocks shape both `apps/www` consumers use, and the in-list position — where a separator must sit *inside* the `<li>` rather than carry a role on it, the trap `sidebar-separator.tsx` already documents.

## Affected workspaces

- [ ] `apps/www`
- [ ] `apps/auth` ⚠️ OAuth provider — affects sign-in for every app
- [ ] `apps/cadence-links`
- [ ] `apps/cms-sanity`
- [x] `packages/cadence-core`
- [ ] `packages/cadence-tokens` ⚠️ requires rebuilding `cadence-core`
- [ ] `packages/cadence-icons`
- [ ] `packages/auth-permissions` ⚠️ lands in all three Next apps at once
- [ ] `packages/email`
- [ ] Other / docs only

## Verification

- [x] `pnpm verify` passes — 21/21 tasks
- [x] Changeset added — `cadence-core` patch

Beyond the gate:

- `cadence-core`: 363 passed, 14 skipped. The 14 are the pre-existing `radio-card` quarantine.
- **Confirmed the suite is not vacuous.** I temporarily performed the A.1 swap the naive way — a plain `<div role="separator" aria-orientation={orientation}>` — and six tests failed on exactly the three points above, then passed again on revert. Nothing from that experiment is in the diff.
- Storybook **not** run. The checklist asks for it when a `cadence-core` component changes; none did here, so there is nothing visual to look at. Contrast is still only checkable in the a11y addon panel — `axeViolations` disables that rule because jsdom has no layout engine.

## Screenshots

n/a — no visual change.

## Notes for the reviewer

**A dead code path worth knowing about for A.1.** `separator.tsx` builds a class name `orientation--${orientation}`, but `separator.module.css` declares no such rule — the module exports only `root` and the eight `color--*` keys. The lookup is `undefined` and `classnames` drops it; orientation styling comes entirely from `[data-orientation]` attribute selectors.

Harmless today, but a rewrite that "tidies up" by keeping the class and dropping the attribute would silently break sizing. One test pins both halves. A.1 should delete the dead lookup.

Not stacked — branches off `main`.